### PR TITLE
Rename node package from @nasa-gcn/gcn-schema to @nasa-gcn/schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@nasa-gcn/gcn-schema",
+  "name": "@nasa-gcn/schema",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nasa-gcn/gcn-schema",
+      "name": "@nasa-gcn/schema",
       "devDependencies": {
         "ajv": "^8.12.0",
         "husky": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nasa-gcn/gcn-schema",
+  "name": "@nasa-gcn/schema",
   "type": "module",
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
It's shorter and less redundant.