### PR TITLE
Example GUANO notices

### DIFF
--- a/gcn/notices/core/DateTime.schema.json
+++ b/gcn/notices/core/DateTime.schema.json
@@ -6,26 +6,21 @@
   "type": "object",
   "properties": {
     "trigger_time": {
-      "type": ["string", "null"],
+      "type": ["string"],
       "description": "Time of the trigger [ISO 8601]"
     },
     "observation_start": {
-      "type": ["string", "null"],
+      "type": ["string"],
       "description": "Start time of the observation [ISO 8601]"
     },
     "observation_stop": {
-      "type": ["string", "null"],
+      "type": ["string"],
       "description": "Stop time of the observation [ISO 8601]"
     },
     "observation_livetime": {
-      "type": ["number", "null"],
+      "type": ["number"],
       "description": "Livetime of the observation [s]"
     }
   },
-  "required": [
-    "trigger_time",
-    "observation_start",
-    "observation_stop",
-    "observation_livetime"
-  ]
+  "required": ["trigger_time"]
 }

--- a/gcn/notices/core/Localization.schema.json
+++ b/gcn/notices/core/Localization.schema.json
@@ -38,15 +38,5 @@
       "type": ["string", "null"],
       "description": "URL of HEALPix localization probability file"
     }
-  },
-  "required": [
-    "ra",
-    "dec",
-    "semi_major",
-    "semi_minor",
-    "position_angle",
-    "containment_probability",
-    "systematic_included",
-    "healpix_url"
-  ]
+  }
 }

--- a/gcn/notices/core/Statistics.schema.json
+++ b/gcn/notices/core/Statistics.schema.json
@@ -39,7 +39,7 @@
     },
     "classification": {
       "type": "object",
-      "additionalProperties": { "type": "string" },
+      "additionalProperties": { "type": "number" },
       "description": "Dictionary mapping mutually exclusive source classes to probabilities between 0 and 1, the sum of all values must be 1. e.g. ({'BNS', 0.9}, {'NSBH', 0.05}, {'BBH', 0.05})"
     },
     "properties": {

--- a/gcn/notices/fermi/gbm/Trigger.example.json
+++ b/gcn/notices/fermi/gbm/Trigger.example.json
@@ -46,7 +46,7 @@
     },
     "p_astro": 0,
     "classification": {
-      "type": "object"
+      "type": 0
     },
     "properties": {
       "type": "object"

--- a/gcn/notices/icecube/amon/GoldAndBronze.example.json
+++ b/gcn/notices/icecube/amon/GoldAndBronze.example.json
@@ -41,7 +41,7 @@
     },
     "p_astro": 0,
     "classification": {
-      "type": "object"
+      "type": 0
     },
     "properties": {
       "type": "object"

--- a/gcn/notices/swift/bat/guano/alert.example.json
+++ b/gcn/notices/swift/bat/guano/alert.example.json
@@ -10,9 +10,6 @@
     "alert_tense": "current",
     "alert_type": "initial"
   },
-  "event_info": {
-    "event_id": "name"
-  },
   "datetime": {
     "trigger_time": "Time of the trigger [ISO 8601]"
   },
@@ -23,9 +20,11 @@
       "energy_low": 15,
       "energy_high": 350
     },
-    "classification": "GRB"
+    "classification": { "GRB": 1 }
   },
   "identifiers": {
-    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/"
+    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/",
+    "instrument_id": "700000031",
+    "instrument_id_alternate": "7000000000"
   }
 }

--- a/gcn/notices/swift/bat/guano/alert.example.json
+++ b/gcn/notices/swift/bat/guano/alert.example.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
+  "alert_reporter": {
+    "mission": "Swift",
+    "instrument": "BAT-GUANO",
+    "record_number": 1
+  },
+  "alert_info": {
+    "alert_datetime": "[UTC, ISO 8601]",
+    "alert_tense": "current",
+    "alert_type": "initial"
+  },
+  "event_info": {
+    "event_id": "name"
+  },
+  "datetime": {
+    "trigger_time": "Time of the trigger [ISO 8601]"
+  },
+  "statistics": {
+    "rate_snr": 7.5,
+    "rate_duration": 0.256,
+    "rate_energy_range": {
+      "energy_low": 15,
+      "energy_high": 350
+    },
+    "classification": "GRB"
+  },
+  "identifiers": {
+    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/"
+  }
+}

--- a/gcn/notices/swift/bat/guano/alert.schema.json
+++ b/gcn/notices/swift/bat/guano/alert.schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "alert_reporter": {
+      "$ref": "/schema/gcn/notices/core/AlertReporter.schema.json"
+    },
+    "alert_info": {
+      "$ref": "/schema/gcn/notices/core/AlertInfo.schema.json"
+    },
+    "event_info": {
+      "$ref": "/schema/gcn/notices/core/EventInfo.schema.json"
+    },
+    "datetime": {
+      "$ref": "/schema/gcn/notices/core/DateTime.schema.json"
+    },
+    "localization": {
+      "$ref": "/schema/gcn/notices/core/Localization.schema.json"
+    },
+    "statistics": {
+      "$ref": "/schema/gcn/notices/core/Statistics.schema.json"
+    },
+    "identifiers": {
+      "$ref": "/schema/gcn/notices/core/Identifiers.schema.json",
+      "description": "data archive only"
+    }
+  },
+  "required": [
+    "alert_reporter",
+    "alert_info",
+    "event_info",
+    "datetime",
+    "identifiers"
+  ]
+}

--- a/gcn/notices/swift/bat/guano/alert.schema.json
+++ b/gcn/notices/swift/bat/guano/alert.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
-  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "alert_reporter": {
@@ -9,8 +9,8 @@
     "alert_info": {
       "$ref": "/schema/gcn/notices/core/AlertInfo.schema.json"
     },
-    "event_info": {
-      "$ref": "/schema/gcn/notices/core/EventInfo.schema.json"
+    "identifiers": {
+      "$ref": "/schema/gcn/notices/core/Identifiers.schema.json"
     },
     "datetime": {
       "$ref": "/schema/gcn/notices/core/DateTime.schema.json"
@@ -20,17 +20,7 @@
     },
     "statistics": {
       "$ref": "/schema/gcn/notices/core/Statistics.schema.json"
-    },
-    "identifiers": {
-      "$ref": "/schema/gcn/notices/core/Identifiers.schema.json",
-      "description": "data archive only"
     }
   },
-  "required": [
-    "alert_reporter",
-    "alert_info",
-    "event_info",
-    "datetime",
-    "identifiers"
-  ]
+  "required": ["alert_reporter", "alert_info", "identifiers", "datetime"]
 }

--- a/gcn/notices/swift/bat/guano/loc-arcmin.example.json
+++ b/gcn/notices/swift/bat/guano/loc-arcmin.example.json
@@ -10,9 +10,6 @@
     "alert_tense": "current",
     "alert_type": "update"
   },
-  "event_info": {
-    "event_id": "name"
-  },
   "datetime": {
     "trigger_time": "Time of the trigger [ISO 8601]"
   },
@@ -21,7 +18,7 @@
     "dec": 37.6,
     "semi_major": 0.03,
     "containment_probability": 0.9,
-    "systematic_included": true,
+    "systematic_included": true
   },
   "statistics": {
     "rate_snr": 7.5,
@@ -36,9 +33,11 @@
       "energy_low": 15,
       "energy_high": 350
     },
-    "classification": "GRB"
+    "classification": { "GRB": 1 }
   },
   "identifiers": {
-    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/"
+    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/",
+    "instrument_id": "700000031",
+    "instrument_id_alternate": "7000000000"
   }
 }

--- a/gcn/notices/swift/bat/guano/loc-arcmin.example.json
+++ b/gcn/notices/swift/bat/guano/loc-arcmin.example.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
+  "alert_reporter": {
+    "mission": "Swift",
+    "instrument": "BAT-GUANO",
+    "record_number": 3
+  },
+  "alert_info": {
+    "alert_datetime": "[UTC, ISO 8601]",
+    "alert_tense": "current",
+    "alert_type": "update"
+  },
+  "event_info": {
+    "event_id": "name"
+  },
+  "datetime": {
+    "trigger_time": "Time of the trigger [ISO 8601]"
+  },
+  "localization": {
+    "ra": 193.8,
+    "dec": 37.6,
+    "semi_major": 0.03,
+    "containment_probability": 0.9,
+    "systematic_included": true,
+  },
+  "statistics": {
+    "rate_snr": 7.5,
+    "rate_duration": 0.256,
+    "rate_energy_range": {
+      "energy_low": 15,
+      "energy_high": 350
+    },
+    "image_snr": 6,
+    "image_duration": 0.256,
+    "image_energy_range": {
+      "energy_low": 15,
+      "energy_high": 350
+    },
+    "classification": "GRB"
+  },
+  "identifiers": {
+    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/"
+  }
+}

--- a/gcn/notices/swift/bat/guano/loc-map.example.json
+++ b/gcn/notices/swift/bat/guano/loc-map.example.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
+  "alert_reporter": {
+    "mission": "Swift",
+    "instrument": "BAT-GUANO",
+    "record_number": 2
+  },
+  "alert_info": {
+    "alert_datetime": "[UTC, ISO 8601]",
+    "alert_tense": "current",
+    "alert_type": "update"
+  },
+  "event_info": {
+    "event_id": "name"
+  },
+  "datetime": {
+    "trigger_time": "Time of the trigger [ISO 8601]"
+  },
+  "localization": {
+    "systematic_included": true,
+    "healpix_url": "https://healpix.gsfc.nasa.gov"
+  },
+  "statistics": {
+    "rate_snr": 7.5,
+    "rate_duration": 0.256,
+    "rate_energy_range": {
+      "energy_low": 15,
+      "energy_high": 350
+    },
+    "classification": "GRB"
+  },
+  "identifiers": {
+    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/"
+  }
+}

--- a/gcn/notices/swift/bat/guano/loc-map.example.json
+++ b/gcn/notices/swift/bat/guano/loc-map.example.json
@@ -10,9 +10,6 @@
     "alert_tense": "current",
     "alert_type": "update"
   },
-  "event_info": {
-    "event_id": "name"
-  },
   "datetime": {
     "trigger_time": "Time of the trigger [ISO 8601]"
   },
@@ -27,9 +24,11 @@
       "energy_low": 15,
       "energy_high": 350
     },
-    "classification": "GRB"
+    "classification": { "GRB": 1 }
   },
   "identifiers": {
-    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/"
+    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/",
+    "instrument_id": "700000031",
+    "instrument_id_alternate": "7000000000"
   }
 }

--- a/gcn/notices/swift/bat/guano/retraction.example.json
+++ b/gcn/notices/swift/bat/guano/retraction.example.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
+  "alert_reporter": {
+    "mission": "Swift",
+    "instrument": "BAT-GUANO",
+    "record_number": 4
+  },
+  "alert_info": {
+    "alert_datetime": "[UTC, ISO 8601]",
+    "alert_tense": "current",
+    "alert_type": "retraction"
+  },
+  "event_info": {
+    "event_id": "name"
+  },
+  "datetime": {
+    "trigger_time": "Time of the trigger [ISO 8601]"
+  },
+  "identifiers": {
+    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/"
+  }
+}

--- a/gcn/notices/swift/bat/guano/retraction.example.json
+++ b/gcn/notices/swift/bat/guano/retraction.example.json
@@ -10,13 +10,12 @@
     "alert_tense": "current",
     "alert_type": "retraction"
   },
-  "event_info": {
-    "event_id": "name"
-  },
   "datetime": {
     "trigger_time": "Time of the trigger [ISO 8601]"
   },
   "identifiers": {
-    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/"
+    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/",
+    "instrument_id": "700000031",
+    "instrument_id_alternate": "7000000000"
   }
 }


### PR DESCRIPTION
Has a GUANO notice schema with 4 example use cases:
Alert
Arcmin Pos
Healpix Pos
Retraction

In addition, it has changes to core schema to fix silly things, and changes to Fermi+IceCube to match.