### PR TITLE
Flat schema

### DIFF
--- a/gcn/notices/core/EnergyRange.schema.json
+++ b/gcn/notices/core/EnergyRange.schema.json
@@ -15,14 +15,17 @@
     },
     "band": {
       "enum": ["energy", "wavelength", "frequency"],
-      "description": "high energy or optical or radio observations",
+      "description": "high-energy or optical or radio observations, default property is energy",
       "type": "string"
     },
     "units": {
       "enum": ["keV", "nm", "Hz"],
-      "description": "units of band range",
+      "description": "Units of band range, default unit is keV",
       "type": "string"
+    },
+    "filter": {
+      "type": "string",
+      "description": "Filter name, as used in optical observations"
     }
-  },
-  "required": ["band", "units"]
+  }
 }

--- a/gcn/notices/core/EnergyRange.schema.json
+++ b/gcn/notices/core/EnergyRange.schema.json
@@ -7,11 +7,22 @@
   "properties": {
     "energy_low": {
       "type": "number",
-      "description": "low energy bound in range [keV]"
+      "description": "lower bound in range"
     },
     "energy_high": {
       "type": "number",
-      "description": "high energy bound in range [keV]"
+      "description": "higher bound in range"
+    },
+    "band": {
+      "enum": ["energy", "wavelength", "frequency"],
+      "description": "high energy or optical or radio observations",
+      "type": "string"
+    },
+    "units": {
+      "enum": ["keV", "nm", "Hz"],
+      "description": "units of band range",
+      "type": "string"
     }
-  }
+  },
+  "required": ["band", "units"]
 }

--- a/gcn/notices/fermi/gbm/Trigger.example.json
+++ b/gcn/notices/fermi/gbm/Trigger.example.json
@@ -30,13 +30,17 @@
     "rate_duration": 0,
     "rate_energy_range": {
       "energy_low": 0,
-      "energy_high": 100
+      "energy_high": 100,
+      "band": "energy",
+      "units": "keV"
     },
     "image_snr": 0,
     "image_duration": 0,
     "image_energy_range": {
       "energy_low": 0,
-      "energy_high": 100
+      "energy_high": 100,
+      "band": "energy",
+      "units": "keV"
     },
     "p_astro": 0,
     "classification": {
@@ -50,7 +54,9 @@
     "hardness_ratio": 0,
     "energy_range": {
       "energy_low": 0,
-      "energy_high": 100
+      "energy_high": 100,
+      "band": "energy",
+      "units": "keV"
     }
   },
   "additional_info": {

--- a/gcn/notices/fermi/gbm/allOfEx.example.json
+++ b/gcn/notices/fermi/gbm/allOfEx.example.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://gcn.nasa.gov/schema/gcn/notices/fermi/gbm/allOfEx.schema.json",
+
+  "alert": {
+    "datetime_of_notice": "2023-04-11T15:23:00Z",
+    "alert_tense": "current",
+    "alert_type": "initial"
+  },
+
+  "datetime": {
+    "trigger_time": "2023-04-11T15:23:30Z",
+    "observation_start": "2023-04-11T15:23:45Z",
+    "observation_stop": "2023-04-11T15:24:30Z",
+    "observation_livetime": 0
+  }
+}

--- a/gcn/notices/fermi/gbm/allOfEx.schema.json
+++ b/gcn/notices/fermi/gbm/allOfEx.schema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://gcn.nasa.gov/schema/gcn/notices/fermi/gbm/allOfEx.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Trigger",
+  "description": "fermi gbm Trigger",
+  "type": "object",
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "alert": {
+          "$ref": "/schema/gcn/notices/core/Alert.schema.json"
+        },
+        "datetime": {
+          "$ref": "/schema/gcn/notices/core/DateTime.schema.json"
+        }
+      }
+    }
+  ]
+}

--- a/gcn/notices/fermi/lat/Alert.example.json
+++ b/gcn/notices/fermi/lat/Alert.example.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://gcn.nasa.gov/schema/gcn/notices/fermi/lat/Alert.schema.json",
+
+  "datetime_of_notice": "2023-04-13 10:22:30",
+  "alert_tense": "current",
+  "alert_type": "initial",
+
+  "mission": "Fermi",
+  "instrument": "LAT",
+  "record_number": 1,
+
+  "event_name": ["GRB221009A"],
+  "id": ["bn221009553"],
+
+  "trigger_time": "2022-10-09 17:33:54",
+
+  "ra": 288.282,
+  "dec": 19.495,
+
+  "position_angle": 0.0,
+  "healpix_url": "glg_healpix_all_bn221009553_v01",
+
+  "additional_info": "This Notice was ground-generated -- not flight-generated. ",
+
+  "significance": 5.59
+}

--- a/gcn/notices/fermi/lat/Alert.schema.json
+++ b/gcn/notices/fermi/lat/Alert.schema.json
@@ -4,36 +4,36 @@
   "title": "Alert",
   "description": "fermi lat Alerts",
   "type": "object",
-  "properties": {
-    "alert_info": {
+  "allOf": [
+    {
       "$ref": "/schema/gcn/notices/core/Alert.schema.json"
     },
-    "alert_reporter": {
+    {
       "$ref": "/schema/gcn/notices/core/Reporter.schema.json"
     },
-    "event_info": {
+    {
       "$ref": "/schema/gcn/notices/core/Event.schema.json"
     },
-    "datetime": {
+    {
       "$ref": "/schema/gcn/notices/core/DateTime.schema.json"
     },
-    "localization": {
+    {
       "$ref": "/schema/gcn/notices/core/Localization.schema.json"
     },
-    "statistics": {
+    {
       "$ref": "/schema/gcn/notices/core/Statistics.schema.json"
     },
-    "comments": {
-      "$ref": "/schema/gcn/notices/core/Comments.schema.json"
+    {
+      "$ref": "/schema/gcn/notices/core/AdditionalInfo.schema.json"
     },
-    "grb_duration": {
+    {
       "$ref": "/schema/gcn/notices/core/Duration.schema.json"
     },
-    "grb_spectral": {
+    {
       "$ref": "/schema/gcn/notices/core/spectral/GammaRay.schema.json"
     },
-    "lat_onboard": {
+    {
       "$ref": "/schema/gcn/notices/fermi/lat/OnboardTrigger.schema.json"
     }
-  }
+  ]
 }

--- a/gcn/notices/fermi/lat/OnboardTrigger.schema.json
+++ b/gcn/notices/fermi/lat/OnboardTrigger.schema.json
@@ -49,18 +49,5 @@
       "type": "number",
       "description": "Time of last photon used in the location calculation [ISO 8601]"
     }
-  },
-  "required": [
-    "phi",
-    "theta",
-    "data_timescale",
-    "grb_intensity_total",
-    "grb_intensity1",
-    "grb_intensity2",
-    "grb_intensity3",
-    "grb_intensity4",
-    "significance",
-    "first_photon",
-    "last_photon"
-  ]
+  }
 }

--- a/gcn/notices/icecube/GoldAndBronze.example.json
+++ b/gcn/notices/icecube/GoldAndBronze.example.json
@@ -31,12 +31,16 @@
     "rate_duration": 0,
     "rate_energy_range": {
       "energy_low": 0,
+      "band": "energy",
+      "units": "keV",
       "energy_high": 0
     },
     "image_snr": 0,
     "image_duration": 0,
     "image_energy_range": {
       "energy_low": 0,
+      "band": "energy",
+      "units": "keV",
       "energy_high": 0
     },
     "p_astro": 0,

--- a/gcn/notices/swift/bat/guano/alert.example.json
+++ b/gcn/notices/swift/bat/guano/alert.example.json
@@ -18,7 +18,9 @@
     "rate_duration": 0.256,
     "rate_energy_range": {
       "energy_low": 15,
-      "energy_high": 350
+      "energy_high": 350,
+      "band": "energy",
+      "units": "keV"
     },
     "classification": { "GRB": 1 }
   },

--- a/gcn/notices/swift/bat/guano/loc-arcmin.example.json
+++ b/gcn/notices/swift/bat/guano/loc-arcmin.example.json
@@ -25,13 +25,17 @@
     "rate_duration": 0.256,
     "rate_energy_range": {
       "energy_low": 15,
-      "energy_high": 350
+      "energy_high": 350,
+      "band": "energy",
+      "units": "keV"
     },
     "image_snr": 6,
     "image_duration": 0.256,
     "image_energy_range": {
       "energy_low": 15,
-      "energy_high": 350
+      "energy_high": 350,
+      "band": "energy",
+      "units": "keV"
     },
     "classification": { "GRB": 1 }
   },

--- a/gcn/notices/swift/bat/guano/loc-map.example.json
+++ b/gcn/notices/swift/bat/guano/loc-map.example.json
@@ -22,7 +22,9 @@
     "rate_duration": 0.256,
     "rate_energy_range": {
       "energy_low": 15,
-      "energy_high": 350
+      "energy_high": 350,
+      "band": "energy",
+      "units": "keV"
     },
     "classification": { "GRB": 1 }
   },


### PR DESCRIPTION
@dakota002 Don't merge this branch.
This is ex of allOf, it doesn't help with making it flat schema. 

What about if we add some line in validate.mjs code for making the schema flat? Then validating the flat schema example against new schema?
Something like: 
"flat_schema = {}
for key, value in structured_schema.items():
    if isinstance(value, dict):
        for sub_key, sub_value in value.items():
            flat_schema[sub_key] = sub_value
    else:
        flat_schema[key] = value"