### PR TITLE
Remove unions with null

### DIFF
--- a/gcn/notices/core/Localization.schema.json
+++ b/gcn/notices/core/Localization.schema.json
@@ -6,27 +6,27 @@
   "description": "Localization of transient",
   "properties": {
     "ra": {
-      "type": ["number", "null"],
+      "type": "number",
       "description": "ICRS right ascension [deg]"
     },
     "dec": {
-      "type": ["number", "null"],
+      "type": "number",
       "description": "ICRS declination [deg]"
     },
     "semi_major": {
-      "type": ["number", "null"],
+      "type": "number",
       "description": "Uncertainty ellipse semi-major axis [deg]"
     },
     "semi_minor": {
-      "type": ["number", "null"],
+      "type": "number",
       "description": "Uncertainty ellipse semi-minor axis, or null if ellipse is a circle [deg]"
     },
     "position_angle": {
-      "type": ["number", "null"],
+      "type": "number",
       "description": "Position angle of semi-major axis [deg]"
     },
     "containment_probability": {
-      "type": ["number", "null"],
+      "type": "number",
       "description": "Containment probability [dimensionless, 0-1]"
     },
     "systematic_included": {
@@ -35,7 +35,7 @@
       "default": false
     },
     "healpix_url": {
-      "type": ["string", "null"],
+      "type": "string",
       "description": "URL of HEALPix localization probability file"
     }
   }


### PR DESCRIPTION
In JSON Schema, all fields are optional unless they are required.

These fields can already be omitted. Let's not have the redundant and confusing option of having the fields present but null.