### PR TITLE
GUANO notices

### DIFF
--- a/gcn/notices/core/Alert.schema.json
+++ b/gcn/notices/core/Alert.schema.json
@@ -5,7 +5,7 @@
   "description": "Alert Information description properties of this notice",
   "type": "object",
   "properties": {
-    "datetime_of_notice": {
+    "alert_datetime": {
       "type": "string",
       "description": "Date and time of notice creation [UTC, ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ"
     },

--- a/gcn/notices/fermi/lat/Alert.example.json
+++ b/gcn/notices/fermi/lat/Alert.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gcn.nasa.gov/schema/gcn/notices/fermi/lat/Alert.schema.json",
 
-  "datetime_of_notice": "2022-10-10T10:22:30Z",
+  "alert_datetime": "2022-10-10T10:22:30Z",
   "alert_tense": "current",
   "alert_type": "initial",
 

--- a/gcn/notices/glowbug/alert.example.json
+++ b/gcn/notices/glowbug/alert.example.json
@@ -3,7 +3,7 @@
 
   "mission": "GLOWBUG",
 
-  "datetime_of_notice": "2023-04-23T15:25:55Z",
+  "alert_datetime": "2023-04-23T15:25:55Z",
   "alert_tense": "current",
   "alert_type": "initial",
 

--- a/gcn/notices/icecube/GoldAndBronze.example.json
+++ b/gcn/notices/icecube/GoldAndBronze.example.json
@@ -2,7 +2,7 @@
   "$schema": "https://gcn.nasa.gov/schema/gcn/notices/icecube/GoldAndBronze.schema.json",
   "additional_info": "IceCube Bronze Neutrino Track Alert",
   "id": ["137840", "57034692"],
-  "datetime_of_notice": "2023-04-16T05:22:29.55Z",
+  "alert_datetime": "2023-04-16T05:22:29.55Z",
   "alert_type": "initial",
   "ra": 345.82,
   "dec": 9.01,

--- a/gcn/notices/icecube/GoldAndBronze.example_update.json
+++ b/gcn/notices/icecube/GoldAndBronze.example_update.json
@@ -3,7 +3,7 @@
   "additional_info": "IceCube Bronze Neutrino Track Alert",
   "event_name": ["IceCube-230416A"],
   "id": ["137840", "57034692"],
-  "datetime_of_notice": "2023-04-16T05:42:00.0Z",
+  "alert_datetime": "2023-04-16T05:42:00.0Z",
   "alert_type": "update",
   "ra": 345.82,
   "dec": 9.01,

--- a/gcn/notices/swift/bat/guano/alert.example.json
+++ b/gcn/notices/swift/bat/guano/alert.example.json
@@ -1,26 +1,20 @@
 {
   "$schema": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
-  "alert_reporter": {
-    "mission": "Swift",
-    "instrument": "BAT-GUANO",
-    "record_number": 1
-  },
-  "alert_info": {
-    "alert_datetime": "[UTC, ISO 8601]",
-    "alert_tense": "current",
-    "alert_type": "initial"
-  },
-  "datetime": {
-    "trigger_time": "Time of the trigger [ISO 8601]"
-  },
-  "statistics": {
-    "rate_snr": 7.5,
-    "rate_duration": 0.256,
-    "rate_energy_range": [15, 350],
-    "classification": { "GRB": 1 }
-  },
-  "event": {
-    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/",
-    "id": [700000031, 7000000000]
-  }
+  "mission": "Swift",
+  "instrument": "BAT-GUANO",
+  "messenger": "EM",
+  "record_number": 1,
+  "alert_datetime": "2023-01-01T03:24:36.0Z",
+  "alert_tense": "current",
+  "alert_type": "initial",
+  "trigger_time": "2022-12-31T21:46:05.13Z",
+  "rate_snr": 15.8,
+  "rate_duration": 0.256,
+  "rate_energy_range": [15, 350],
+  "classification": { "GRB": 1 },
+  "far": 0.00001,
+  "follow_up_event": "Fermi 694215970",
+  "follow_up_type": "GRB",
+  "data_archive_page": "https://guano.swift.psu.edu/trigger_report?id=694215995",
+  "id": [694215995]
 }

--- a/gcn/notices/swift/bat/guano/alert.schema.json
+++ b/gcn/notices/swift/bat/guano/alert.schema.json
@@ -1,26 +1,42 @@
 {
   "$id": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Swift/BAT-GUANO Alert",
+  "description": "Candidate gamma-ray transient reported from the BAT-GUANO targeted search",
   "type": "object",
-  "properties": {
-    "alert_reporter": {
-      "$ref": "/schema/gcn/notices/core/Reporter.schema.json"
-    },
-    "alert_info": {
+  "allOf": [
+    {
       "$ref": "/schema/gcn/notices/core/Alert.schema.json"
     },
-    "event": {
+    {
       "$ref": "/schema/gcn/notices/core/Event.schema.json"
     },
-    "datetime": {
+    {
       "$ref": "/schema/gcn/notices/core/DateTime.schema.json"
     },
-    "localization": {
+    {
       "$ref": "/schema/gcn/notices/core/Localization.schema.json"
     },
-    "statistics": {
+    {
       "$ref": "/schema/gcn/notices/core/Statistics.schema.json"
+    },
+    {
+      "$ref": "/schema/gcn/notices/core/Reporter.schema.json"
+    },
+    {
+      "$ref": "/schema/gcn/notices/core/AdditionalInfo.schema.json"
+    }
+  ],
+  "properties": {
+    "$schema": true,
+    "follow_up_event": {
+      "type": "string",
+      "description": "Name or trigger time of the external trigger that launched the search."
+    },
+    "follow_up_type": {
+      "type": "string",
+      "description": "Type of external trigger that launched the search, eg GW, neutrino, etc."
     }
   },
-  "required": ["alert_reporter", "alert_info", "event", "datetime"]
+  "unevaluatedProperties": false
 }

--- a/gcn/notices/swift/bat/guano/loc-arcmin.example.json
+++ b/gcn/notices/swift/bat/guano/loc-arcmin.example.json
@@ -1,36 +1,28 @@
 {
   "$schema": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
-  "alert_reporter": {
-    "mission": "Swift",
-    "instrument": "BAT-GUANO",
-    "record_number": 3
-  },
-  "alert_info": {
-    "alert_datetime": "[UTC, ISO 8601]",
-    "alert_tense": "current",
-    "alert_type": "update"
-  },
-  "datetime": {
-    "trigger_time": "Time of the trigger [ISO 8601]"
-  },
-  "localization": {
-    "ra": 193.8,
-    "dec": 37.6,
-    "ra_uncertainty": [0.03],
-    "containment_probability": 0.9,
-    "systematic_included": true
-  },
-  "statistics": {
-    "rate_snr": 7.5,
-    "rate_duration": 0.256,
-    "rate_energy_range": [15, 350],
-    "image_snr": 6,
-    "image_duration": 0.256,
-    "image_energy_range": [15, 350],
-    "classification": { "GRB": 1 }
-  },
-  "event": {
-    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/",
-    "id": [700000031, 7000000000]
-  }
+  "mission": "Swift",
+  "instrument": "BAT-GUANO",
+  "messenger": "EM",
+  "record_number": 3,
+  "alert_datetime": "2023-01-01T05:33:01Z",
+  "alert_tense": "current",
+  "alert_type": "update",
+  "trigger_time": "2022-12-31T21:46:05.13Z",
+  "ra": 336.26,
+  "dec": 25.139,
+  "ra_uncertainty": [0.05],
+  "containment_probability": 0.9,
+  "systematic_included": true,
+  "rate_snr": 15.8,
+  "rate_duration": 0.256,
+  "rate_energy_range": [15, 350],
+  "image_snr": 13.94,
+  "image_duration": 0.256,
+  "image_energy_range": [15, 350],
+  "classification": { "GRB": 1 },
+  "far": 0.00001,
+  "follow_up_event": "Fermi 694215970",
+  "follow_up_type": "GRB",
+  "data_archive_page": "https://guano.swift.psu.edu/trigger_report?id=694215995",
+  "id": [694215995]
 }

--- a/gcn/notices/swift/bat/guano/loc-map.example.json
+++ b/gcn/notices/swift/bat/guano/loc-map.example.json
@@ -1,30 +1,22 @@
 {
   "$schema": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
-  "alert_reporter": {
-    "mission": "Swift",
-    "instrument": "BAT-GUANO",
-    "record_number": 2
-  },
-  "alert_info": {
-    "alert_datetime": "[UTC, ISO 8601]",
-    "alert_tense": "current",
-    "alert_type": "update"
-  },
-  "datetime": {
-    "trigger_time": "Time of the trigger [ISO 8601]"
-  },
-  "localization": {
-    "systematic_included": true,
-    "healpix_url": "https://healpix.gsfc.nasa.gov"
-  },
-  "statistics": {
-    "rate_snr": 7.5,
-    "rate_duration": 0.256,
-    "rate_energy_range": [15, 350],
-    "classification": { "GRB": 1 }
-  },
-  "event": {
-    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/",
-    "id": [700000031, 7000000000]
-  }
+  "mission": "Swift",
+  "instrument": "BAT-GUANO",
+  "messenger": "EM",
+  "record_number": 2,
+  "alert_datetime": "2023-01-01T03:24:36.0Z",
+  "alert_tense": "current",
+  "alert_type": "update",
+  "trigger_time": "2022-12-31T21:46:05.13Z",
+  "healpix_file": "hhhh...",
+  "systematic_included": true,
+  "rate_snr": 7.5,
+  "rate_duration": 0.256,
+  "rate_energy_range": [15, 350],
+  "classification": { "GRB": 1 },
+  "far": 0.00001,
+  "follow_up_event": "Fermi 694215970",
+  "follow_up_type": "GRB",
+  "data_archive_page": "https://guano.swift.psu.edu/trigger_report?id=694215995",
+  "id": [694215995]
 }

--- a/gcn/notices/swift/bat/guano/retraction.example.json
+++ b/gcn/notices/swift/bat/guano/retraction.example.json
@@ -1,20 +1,15 @@
 {
   "$schema": "https://gcn.nasa.gov/schema/gcn/notices/swift/bat/guano/alert.schema.json",
-  "alert_reporter": {
-    "mission": "Swift",
-    "instrument": "BAT-GUANO",
-    "record_number": 4
-  },
-  "alert_info": {
-    "alert_datetime": "[UTC, ISO 8601]",
-    "alert_tense": "current",
-    "alert_type": "retraction"
-  },
-  "datetime": {
-    "trigger_time": "Time of the trigger [ISO 8601]"
-  },
-  "event": {
-    "data_archive_page": "https://swift.gsfc.nasa.gov/archive/",
-    "id": [700000031, 7000000000]
-  }
+  "mission": "Swift",
+  "instrument": "BAT-GUANO",
+  "messenger": "EM",
+  "record_number": 4,
+  "alert_datetime": "2023-01-01T03:24:36.0Z",
+  "alert_tense": "current",
+  "alert_type": "retraction",
+  "trigger_time": "2022-12-31T21:46:05.13Z",
+  "follow_up_event": "Fermi 694215970",
+  "follow_up_type": "GRB",
+  "data_archive_page": "https://guano.swift.psu.edu/trigger_report?id=694215995",
+  "id": [694215995]
 }


### PR DESCRIPTION
Make GUANO notices work with the new flat structure and core schema
Fix Alert.schema.json to have consistent property names