### PR TITLE
Rename datetime_of_notice to alert_datetime

### DIFF
--- a/gcn/notices/core/Alert.schema.json
+++ b/gcn/notices/core/Alert.schema.json
@@ -5,7 +5,7 @@
   "description": "Alert Information description properties of this notice",
   "type": "object",
   "properties": {
-    "datetime_of_notice": {
+    "alert_datetime": {
       "type": "string",
       "description": "Date and time of notice creation [UTC, ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ"
     },

--- a/gcn/notices/fermi/lat/Alert.example.json
+++ b/gcn/notices/fermi/lat/Alert.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://gcn.nasa.gov/schema/gcn/notices/fermi/lat/Alert.schema.json",
 
-  "datetime_of_notice": "2022-10-10T10:22:30Z",
+  "alert_datetime": "2022-10-10T10:22:30Z",
   "alert_tense": "current",
   "alert_type": "initial",
 

--- a/gcn/notices/glowbug/alert.example.json
+++ b/gcn/notices/glowbug/alert.example.json
@@ -3,7 +3,7 @@
 
   "mission": "GLOWBUG",
 
-  "datetime_of_notice": "2023-04-23T15:25:55Z",
+  "alert_datetime": "2023-04-23T15:25:55Z",
   "alert_tense": "current",
   "alert_type": "initial",
 

--- a/gcn/notices/icecube/GoldAndBronze.example.json
+++ b/gcn/notices/icecube/GoldAndBronze.example.json
@@ -2,7 +2,7 @@
   "$schema": "https://gcn.nasa.gov/schema/gcn/notices/icecube/GoldAndBronze.schema.json",
   "additional_info": "IceCube Bronze Neutrino Track Alert",
   "id": ["137840", "57034692"],
-  "datetime_of_notice": "2023-04-16T05:22:29.55Z",
+  "alert_datetime": "2023-04-16T05:22:29.55Z",
   "alert_type": "initial",
   "ra": 345.82,
   "dec": 9.01,

--- a/gcn/notices/icecube/GoldAndBronze.example_update.json
+++ b/gcn/notices/icecube/GoldAndBronze.example_update.json
@@ -3,7 +3,7 @@
   "additional_info": "IceCube Bronze Neutrino Track Alert",
   "event_name": ["IceCube-230416A"],
   "id": ["137840", "57034692"],
-  "datetime_of_notice": "2023-04-16T05:42:00.0Z",
+  "alert_datetime": "2023-04-16T05:42:00.0Z",
   "alert_type": "update",
   "ra": 345.82,
   "dec": 9.01,


### PR DESCRIPTION
Fixes #82.

This peels off one bug fix from #79 and reconciles all affected schema.

CC @blaufuss, @shb46, @Tohuvavohu, because this affects the IceCube, Glowbug, and GUANO schema.