### PR TITLE
Base schema

### DIFF
--- a/gcn/notices/core/Base.schema.json
+++ b/gcn/notices/core/Base.schema.json
@@ -1,0 +1,13 @@
+{
+  "$id": "https://gcn.nasa.gov/schema/gcn/notices/core/Base.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Base Schema",
+  "description": "A root element that any schema may include in the allOf to add the $schema property. This should be used along with `unevaluatedProperties`:false to catch cases like typos or properties that do not exist",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    }
+  },
+  "required": ["$schema"]
+}

--- a/validate.mjs
+++ b/validate.mjs
@@ -64,7 +64,6 @@ async function validate(path) {
       }
 
       if (ajv.errors) {
-        console.log(ajv.errors)
         process.exitCode = 1
         ajv.errors.forEach(({ message }) =>
           console.error(`error: ${path}: ${message}`)

--- a/validate.mjs
+++ b/validate.mjs
@@ -64,6 +64,7 @@ async function validate(path) {
       }
 
       if (ajv.errors) {
+        console.log(ajv.errors)
         process.exitCode = 1
         ajv.errors.forEach(({ message }) =>
           console.error(`error: ${path}: ${message}`)


### PR DESCRIPTION
This is part of a solution to make the schema more correctly defined. The idea is that any mission can include an allOf section with this field, and the `"unevaluatedProperties":false` setting to catch any unevaluatedProperties (stuff like property name typos or extra properties not defined in the schema)

