### PR TITLE
anyOfs changed to allOf, small update to schema to fix type problem.

### DIFF
--- a/gcn/notices/glowbug/alert.schema.json
+++ b/gcn/notices/glowbug/alert.schema.json
@@ -4,7 +4,7 @@
   "title": "Glowbug Alert Notice",
   "description": "Information about a Glowbug trigger.  All fields optional; omitted if not available or not applicable.",
   "type": "object",
-  "anyOf": [
+  "allOf": [
     {
       "$ref": "/schema/gcn/notices/core/Reporter.schema.json",
       "description": "mission=GLOWBUG"

--- a/gcn/notices/icecube/GoldAndBronze.schema.json
+++ b/gcn/notices/icecube/GoldAndBronze.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "title": "IceCubeGoldAndBronzeTracks",
   "description": "IceCube Astrotrack Gold And Bronze track alert events",
-  "anyOf": [
+  "allOf": [
     {
       "$ref": "/schema/gcn/notices/core/AdditionalInfo.schema.json"
     },
@@ -21,16 +21,10 @@
       "$ref": "/schema/gcn/notices/core/DateTime.schema.json"
     },
     {
-      "$ref": "#/$defs/nu_energy"
-    },
-    {
-      "$ref": "#/$defs/signalness"
-    },
-    {
       "$ref": "/schema/gcn/notices/core/Statistics.schema.json"
     }
   ],
-  "$defs": {
+  "properties": {
     "nu_energy": {
       "description": "Most probable neutrino energy [TeV] that would have produced an event",
       "type": "number"

--- a/gcn/notices/icecube/LvkNuTrackSearch.schema.json
+++ b/gcn/notices/icecube/LvkNuTrackSearch.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "title": "IceCube LVK Alert Nu Track Search",
   "description": "IceCube LVK Coincident Neutrino Track Search",
-  "anyOf": [
+  "allOf": [
     {
       "$ref": "/schema/gcn/notices/core/Alert.schema.json",
       "description": "Alert information (alert_datetime and alert_type) from LVK alert notices"


### PR DESCRIPTION
The change from anyOf to allOf fixes the false positives in validation. 

As a note, omitting fields from the objects added with allOf ( example, omitting `alert_type` when using a `$ref` to the core `Alert` schema) is still valid, as these fields are not required.

