### PR TITLE
Allow any key value pair for reference

### DIFF
--- a/gcn/notices/core/FollowUp.schema.json
+++ b/gcn/notices/core/FollowUp.schema.json
@@ -19,8 +19,7 @@
     },
     "reference": {
       "type": "object",
-      "additionalProperties": { "type": "number" },
-      "description": "Reference as distributed by the notices or circulars or ATel, ex. gcn.notices.Fermi.gbm.alert: 4642"
+      "description": "Key-value pairs to reference notices, circulars, ATel, etc. For notices, the key should be the topic as a string, and the value should be the timestamp of the notice (ex: 'gcn.notices.glowbug.alert':'2023-01-01T03:24:36.0Z'). For circulars the key should be 'gcn.circulars' and the value should be the circular ID (ex: 'gcn.circular':32517)"
     }
   }
 }

--- a/gcn/notices/core/FollowUp.schema.json
+++ b/gcn/notices/core/FollowUp.schema.json
@@ -19,7 +19,7 @@
     },
     "reference": {
       "type": "object",
-      "description": "Key-value pairs to reference notices, circulars, ATel, etc. For notices, the key should be the topic as a string, and the value should be the timestamp of the notice (ex: 'gcn.notices.glowbug.alert':'2023-01-01T03:24:36.0Z'). For circulars the key should be 'gcn.circulars' and the value should be the circular ID (ex: 'gcn.circular':32517)"
+      "description": "Key-value pairs to reference Notices, Circulars, ATel, etc. that point to the reference localization. For notices, provide the topic and timestamp (ex: 'gcn.notices.glowbug.alert':'2023-01-01T03:24:36.0Z') or topic and alert type with use of ref_ID field (ex: 'igwn.gwalert':'PRELIMINARY'). For Circulars or ATels, the key-value pair should be the system and ID (ex: 'circular':32517 or 'atel':12345)."
     }
   }
 }


### PR DESCRIPTION
 Description explains the usage for referencing notices/circulars. Please make any suggestions though if this is not what the intended idea was