### PR TITLE
Include null as option for p-values

### DIFF
--- a/gcn/notices/icecube/LvkNuTrackSearch.example.json
+++ b/gcn/notices/icecube/LvkNuTrackSearch.example.json
@@ -23,7 +23,7 @@
         "systematic_included": false
       },
       "event_pval_generic": 0.0191,
-      "event_pval_bayesian": 0.0549
+      "event_pval_bayesian": null
     },
     {
       "event_dt": 222.46,

--- a/gcn/notices/icecube/LvkNuTrackSearch.schema.json
+++ b/gcn/notices/icecube/LvkNuTrackSearch.schema.json
@@ -23,11 +23,11 @@
   "properties": {
     "pval_generic": {
       "description": "P-value from generic transient search; consistency with background expectations [0-1]",
-      "type": "number"
+      "type": ["number", "null"]
     },
     "pval_bayesian": {
       "description": "P-value from LLAMA Bayesian search; consistency with background expectations [0-1]",
-      "type": "number"
+      "type": ["number", "null"]
     },
     "n_events_coincident": {
       "description": "Number of IceCube events in spatial and temporal coincidence with the GW map",
@@ -71,11 +71,11 @@
         },
         "event_pval_generic": {
           "description": "Per-event P-value from generic transient search; consistency with background expectations [0-1]",
-          "type": "number"
+          "type": ["number", "null"]
         },
         "event_pval_bayesian": {
           "description": "Per-event P-value from LLAMA Bayesian search; consistency with background expectations [0-1]",
-          "type": "number"
+          "type": ["number", "null"]
         }
       }
     }


### PR DESCRIPTION
Make it clear that p-values reported (overall search or per-event one…s) can be null.  This happens when a search is not run for selection reasons, or an individual event is not significant in one search or the other.