### PR TITLE
Fix typo so that lint-staged runs prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "singleQuote": true
   },
   "lint-staged": {
-    "*.(json,js,mjs)": "prettier --write",
+    "*.{json,js,mjs}": "prettier --write",
     "*.schema.json": "node validate.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
Fix a typo in the lint-staged rule for prettier: `*.(json,js,mjs)` should have been `*.{json,js,mjs}`.