### PR TITLE
snake_case and ra_dec_error

### DIFF
--- a/gcn/notices/burstcube/Alert.example.json
+++ b/gcn/notices/burstcube/Alert.example.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/Alert.schema.json",
+  "$schema": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/alert.schema.json",
   "alert_datetime": "2024-06-01T00:05:00.00Z",
   "alert_tense": "current",
   "alert_type": "initial",
@@ -9,9 +9,7 @@
   "id": ["240601000"],
   "ra": 232.0,
   "dec": -53.1,
-  "uncertainty_shape": "circle",
-  "ra_uncertainty": [10],
-  "dec_uncertainty": [10],
+  "ra_dec_error": 10,
   "containment_probability": 0.9,
   "systematic_included": false,
   "healpix_url": "https://heasarc.gsfc.nasa.gov/burstcube/trigger/240601000/current/240601000_locmap.fits",

--- a/gcn/notices/burstcube/Alert.schema.json
+++ b/gcn/notices/burstcube/Alert.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/Alert.schema.json",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/alert.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Alert",
   "description": "BurstCube Trigger Alert",

--- a/gcn/notices/burstcube/Test.example.json
+++ b/gcn/notices/burstcube/Test.example.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/Test.schema.json",
+  "$schema": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/test.schema.json",
   "alert_datetime": "2024-06-01T00:05:00.00Z",
   "alert_tense": "current",
   "alert_type": "initial",
@@ -9,9 +9,7 @@
   "id": ["240601000"],
   "ra": 232.0,
   "dec": -53.1,
-  "uncertainty_shape": "circle",
-  "ra_uncertainty": [10],
-  "dec_uncertainty": [10],
+  "ra_dec_error": 10,
   "containment_probability": 0.9,
   "systematic_included": false,
   "healpix_url": "https://heasarc.gsfc.nasa.gov/burstcube/trigger/240601000/current/240601000_locmap.fits",

--- a/gcn/notices/burstcube/Test.schema.json
+++ b/gcn/notices/burstcube/Test.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/Test.schema.json",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/test.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Alert",
   "description": "BurstCube Trigger Alert",


### PR DESCRIPTION
Two modifications are required:
(a) We decided snake_case convention for schema instead of CamelCase, so the schema should begin with a lowercase letter.
(b) Recent ra_dec_error correction is implementation. 

Please also add Ava as reviewer.