### PR TITLE
EP Notices: Include updated statistics core schema

### DIFF
--- a/gcn/notices/einstein_probe/wxt/alert.schema.example.json
+++ b/gcn/notices/einstein_probe/wxt/alert.schema.example.json
@@ -6,6 +6,9 @@
   "dec": 40,
   "ra_dec_error": 0.02,
   "image_energy_range": [0.5, 4.0],
-  "net_rate": 1.0,
-  "image_snr": 1.0
+  "image_snr": 1.0,
+  "net_count_rate": 1.0,
+  "backgound_count_rate": 0.2,
+  "rate_duration": 10,
+  "rate_energy_range": [0.5, 4.0]
 }

--- a/gcn/notices/einstein_probe/wxt/alert.schema.json
+++ b/gcn/notices/einstein_probe/wxt/alert.schema.json
@@ -9,13 +9,5 @@
     { "$ref": "../../core/Localization.schema.json" },
     { "$ref": "../../core/Reporter.schema.json" },
     { "$ref": "../../core/Statistics.schema.json" }
-  ],
-  "properties": {
-    "$schema": true,
-    "net_rate": {
-      "type": "number",
-      "description": "Net count rate [cnt/sec] of the transient in WXT band (0.5-4.0 keV)."
-    }
-  },
-  "unevaluatedProperties": false
+  ]
 }


### PR DESCRIPTION
@modot we realized that the count's property in EP Schema is relevant for other missions, 
thus, Statistics Core Schema has been updated. 

The following fields are also required with the net count rate property:

- background rate
- Duration
- Energy range (was present in the description)

Please check this PR and add/suggest corrections.  