### PR TITLE
Einstein Probe: add additional_info about net_count_rate

### DIFF
--- a/gcn/notices/einstein_probe/wxt/alert.schema.example.json
+++ b/gcn/notices/einstein_probe/wxt/alert.schema.example.json
@@ -8,5 +8,5 @@
   "image_energy_range": [0.5, 4.0],
   "net_count_rate": 1.0,
   "image_snr": 1.0,
-  "additional_info": "The net count rate is derived from an accumulated image (up to 20 min) in 0.5-4 keV assuming a constant flux. It could be significantly different from the count rate of a short duration burst."
+  "additional_info": "The net count rate is derived from an accumulated image (up to 20 min) in 0.5-4 keV, assuming a constant flux. However, it can be significantly lower than the actual count rate of a burst with a duration much shorter than 20 min."
 }

--- a/gcn/notices/einstein_probe/wxt/alert.schema.example.json
+++ b/gcn/notices/einstein_probe/wxt/alert.schema.example.json
@@ -6,6 +6,7 @@
   "dec": 40,
   "ra_dec_error": 0.02,
   "image_energy_range": [0.5, 4.0],
-  "net_rate": 1.0,
-  "image_snr": 1.0
+  "net_count_rate": 1.0,
+  "image_snr": 1.0,
+  "additional_info": "The net count rate is derived from an accumulated image (up to 20 min) in 0.5-4 keV assuming a constant flux. It could be significantly different from the count rate of a short duration burst."
 }

--- a/gcn/notices/einstein_probe/wxt/alert.schema.json
+++ b/gcn/notices/einstein_probe/wxt/alert.schema.json
@@ -8,14 +8,7 @@
     { "$ref": "../../core/DateTime.schema.json" },
     { "$ref": "../../core/Localization.schema.json" },
     { "$ref": "../../core/Reporter.schema.json" },
-    { "$ref": "../../core/Statistics.schema.json" }
-  ],
-  "properties": {
-    "$schema": true,
-    "net_rate": {
-      "type": "number",
-      "description": "Net count rate [cnt/sec] of the transient in WXT band (0.5-4.0 keV)."
-    }
-  },
-  "unevaluatedProperties": false
+    { "$ref": "../../core/Statistics.schema.json" },
+    { "$ref": "../../core/AdditionalInfo.schema.json" }
+  ]
 }


### PR DESCRIPTION
As discussed in https://github.com/nasa-gcn/gcn-schema/pull/138 , I create a new PR to add a comment to explain the net_count_rate for WXT of Einstein Probe.

