### PR TITLE
Integrate with the JSON Schema CLI for formatting and linting on CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: intelligence-ai/jsonschema@v0.2.0
+      - run: jsonschema lint gcn --extension .schema.json --verbose
+      - run: jsonschema fmt gcn --extension .schema.json --check --verbose
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/gcn/notices/burstcube/alert.schema.json
+++ b/gcn/notices/burstcube/alert.schema.json
@@ -1,26 +1,48 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/alert.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/alert.schema.json",
   "title": "Alert",
   "description": "BurstCube Trigger Alert",
   "type": "object",
   "allOf": [
-    { "$ref": "../core/Alert.schema.json" },
-    { "$ref": "../core/Reporter.schema.json" },
-    { "$ref": "../core/DateTime.schema.json" },
-    { "$ref": "../core/Event.schema.json" },
-    { "$ref": "../core/Localization.schema.json" },
-    { "$ref": "../core/Statistics.schema.json" },
-    { "$ref": "../core/Duration.schema.json" }
+    {
+      "$ref": "../core/Alert.schema.json"
+    },
+    {
+      "$ref": "../core/Reporter.schema.json"
+    },
+    {
+      "$ref": "../core/DateTime.schema.json"
+    },
+    {
+      "$ref": "../core/Event.schema.json"
+    },
+    {
+      "$ref": "../core/Localization.schema.json"
+    },
+    {
+      "$ref": "../core/Statistics.schema.json"
+    },
+    {
+      "$ref": "../core/Duration.schema.json"
+    }
   ],
   "properties": {
     "detector_status": {
       "type": "object",
       "properties": {
-        "CsI0": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI1": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI2": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI3": { "$ref": "../core/DetectorStatus.schema.json" }
+        "CsI0": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI1": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI2": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI3": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        }
       }
     }
   }

--- a/gcn/notices/burstcube/test.schema.json
+++ b/gcn/notices/burstcube/test.schema.json
@@ -1,26 +1,48 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/test.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/burstcube/test.schema.json",
   "title": "Alert",
   "description": "BurstCube Trigger Alert",
   "type": "object",
   "allOf": [
-    { "$ref": "../core/Alert.schema.json" },
-    { "$ref": "../core/Reporter.schema.json" },
-    { "$ref": "../core/DateTime.schema.json" },
-    { "$ref": "../core/Event.schema.json" },
-    { "$ref": "../core/Localization.schema.json" },
-    { "$ref": "../core/Statistics.schema.json" },
-    { "$ref": "../core/Duration.schema.json" }
+    {
+      "$ref": "../core/Alert.schema.json"
+    },
+    {
+      "$ref": "../core/Reporter.schema.json"
+    },
+    {
+      "$ref": "../core/DateTime.schema.json"
+    },
+    {
+      "$ref": "../core/Event.schema.json"
+    },
+    {
+      "$ref": "../core/Localization.schema.json"
+    },
+    {
+      "$ref": "../core/Statistics.schema.json"
+    },
+    {
+      "$ref": "../core/Duration.schema.json"
+    }
   ],
   "properties": {
     "detector_status": {
       "type": "object",
       "properties": {
-        "CsI0": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI1": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI2": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI3": { "$ref": "../core/DetectorStatus.schema.json" }
+        "CsI0": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI1": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI2": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI3": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        }
       }
     }
   }

--- a/gcn/notices/core/AdditionalInfo.schema.json
+++ b/gcn/notices/core/AdditionalInfo.schema.json
@@ -1,13 +1,13 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/AdditionalInfo.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/AdditionalInfo.schema.json",
   "title": "Comments",
   "description": "Comments that are not summarized elsewhere in schema",
+  "type": "object",
   "properties": {
     "additional_info": {
-      "type": "string",
-      "description": "Additional information about the event"
+      "description": "Additional information about the event",
+      "type": "string"
     }
   }
 }

--- a/gcn/notices/core/Alert.schema.json
+++ b/gcn/notices/core/Alert.schema.json
@@ -1,15 +1,16 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Alert.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Alert.schema.json",
   "title": "Alert",
   "description": "Alert Information description properties of this notice",
   "type": "object",
   "properties": {
     "alert_datetime": {
-      "type": "string",
-      "description": "Date and time of notice creation [UTC, ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ"
+      "description": "Date and time of notice creation [UTC, ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ",
+      "type": "string"
     },
     "alert_tense": {
+      "description": "Indication of whether this alert refers to a recent observation (current), re-analysis of archival data (archival), a planned observation in the future (planned), a signal injection (injection), commanded trigger (commanded) or a test trigger (test).",
       "enum": [
         "current",
         "archival",
@@ -17,12 +18,15 @@
         "injection",
         "commanded",
         "test"
-      ],
-      "description": "Indication of whether this alert refers to a recent observation (current), re-analysis of archival data (archival), a planned observation in the future (planned), a signal injection (injection), commanded trigger (commanded) or a test trigger (test)."
+      ]
     },
     "alert_type": {
-      "enum": ["initial", "update", "retraction"],
-      "description": "Indication of alert sequence if multiple of same type sent"
+      "description": "Indication of alert sequence if multiple of same type sent",
+      "enum": [
+        "initial",
+        "update",
+        "retraction"
+      ]
     }
   }
 }

--- a/gcn/notices/core/DateTime.schema.json
+++ b/gcn/notices/core/DateTime.schema.json
@@ -1,25 +1,25 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/DateTime.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/DateTime.schema.json",
   "title": "DateTime",
   "description": "Time descriptions of transient event and observation",
   "type": "object",
   "properties": {
-    "trigger_time": {
-      "type": "string",
-      "description": "Time of the trigger [ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ"
+    "observation_livetime": {
+      "description": "Livetime of the observation [s]",
+      "type": "number"
     },
     "observation_start": {
-      "type": "string",
-      "description": "Start time of the observation [ISO 8601]"
+      "description": "Start time of the observation [ISO 8601]",
+      "type": "string"
     },
     "observation_stop": {
-      "type": "string",
-      "description": "Stop time of the observation [ISO 8601]"
+      "description": "Stop time of the observation [ISO 8601]",
+      "type": "string"
     },
-    "observation_livetime": {
-      "type": "number",
-      "description": "Livetime of the observation [s]"
+    "trigger_time": {
+      "description": "Time of the trigger [ISO 8601], ex YYYY-MM-DDTHH:MM:SS.ssssssZ",
+      "type": "string"
     }
   }
 }

--- a/gcn/notices/core/DetectorStatus.schema.json
+++ b/gcn/notices/core/DetectorStatus.schema.json
@@ -1,7 +1,11 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/DetectorStatus.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/DetectorStatus.schema.json",
   "title": "DetectorStatus",
-  "enum": ["on", "off", "triggered"],
-  "description": "Status of a specified detector at the time of the alert"
+  "description": "Status of a specified detector at the time of the alert",
+  "enum": [
+    "on",
+    "off",
+    "triggered"
+  ]
 }

--- a/gcn/notices/core/Distance.schema.json
+++ b/gcn/notices/core/Distance.schema.json
@@ -1,19 +1,21 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Distance.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Distance.schema.json",
   "title": "Distance",
   "description": "Luminosity Distance",
+  "type": "object",
   "properties": {
     "luminosity_distance": {
-      "type": "number",
-      "description": "Luminosity distance [Mpc]"
+      "description": "Luminosity distance [Mpc]",
+      "type": "number"
     },
     "luminosity_distance_error": {
+      "description": "Luminosity distance uncertainty [Mpc, 1-sigma], with optional asymmetric uncertainty",
       "type": "array",
-      "items": { "type": "number" },
       "maxItems": 2,
-      "description": "Luminosity distance uncertainty [Mpc, 1-sigma], with optional asymmetric uncertainty"
+      "items": {
+        "type": "number"
+      }
     }
   }
 }

--- a/gcn/notices/core/Duration.schema.json
+++ b/gcn/notices/core/Duration.schema.json
@@ -1,28 +1,32 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Duration.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Duration.schema.json",
   "title": "Duration",
+  "type": "object",
   "properties": {
-    "t90": {
-      "type": "number",
-      "description": "Time duration of central 90% of integrated fluence [s]"
-    },
-    "t90_error": {
-      "type": "array",
-      "items": { "type": "number" },
-      "maxItems": 2,
-      "description": "1-sigma uncertainty of the T90 duration [s], with asymmetric statistical errors taken into account"
-    },
     "t50": {
-      "type": "number",
-      "description": "Time duration of central 50% of integrated fluence [s]"
+      "description": "Time duration of central 50% of integrated fluence [s]",
+      "type": "number"
     },
     "t50_error": {
+      "description": "1-sigma uncertainty of the T50 duration [s], with asymmetric statistical errors taken into account",
       "type": "array",
-      "items": { "type": "number" },
       "maxItems": 2,
-      "description": "1-sigma uncertainty of the T50 duration [s], with asymmetric statistical errors taken into account"
+      "items": {
+        "type": "number"
+      }
+    },
+    "t90": {
+      "description": "Time duration of central 90% of integrated fluence [s]",
+      "type": "number"
+    },
+    "t90_error": {
+      "description": "1-sigma uncertainty of the T90 duration [s], with asymmetric statistical errors taken into account",
+      "type": "array",
+      "maxItems": 2,
+      "items": {
+        "type": "number"
+      }
     }
   }
 }

--- a/gcn/notices/core/Event.schema.json
+++ b/gcn/notices/core/Event.schema.json
@@ -1,23 +1,34 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Event.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Event.schema.json",
   "title": "Event Information",
   "description": "Name or names of the event",
+  "type": "object",
   "properties": {
-    "event_name": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Name of the event (ex: GRB 170817A, GW170817, AT2017gfo, SSS 17a)"
-    },
     "id": {
+      "description": "Instrument-specific trigger ID (ex: bn230313485 (Fermi), 1159327 (Swift)) or alternate ID",
       "type": "array",
-      "items": { "oneOf": [{ "type": "string" }, { "type": "number" }] },
-      "description": "Instrument-specific trigger ID (ex: bn230313485 (Fermi), 1159327 (Swift)) or alternate ID"
+      "items": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
     },
     "data_archive_page": {
-      "type": "string",
-      "description": "URL of archived data files"
+      "description": "URL of archived data files",
+      "type": "string"
+    },
+    "event_name": {
+      "description": "Name of the event (ex: GRB 170817A, GW170817, AT2017gfo, SSS 17a)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/gcn/notices/core/FollowUp.schema.json
+++ b/gcn/notices/core/FollowUp.schema.json
@@ -1,26 +1,31 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/FollowUp.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/FollowUp.schema.json",
   "title": "FollowUp",
   "description": "Schema specific to follow-up cases",
   "type": "object",
   "properties": {
-    "ref_type": {
-      "type": "string",
-      "description": "Type of the event detected, ex. GRB, GW, neutrino"
+    "ref_ID": {
+      "description": "Trigger ID as reported by the reference instrument, ex. bnYYMMDDFF",
+      "type": "string"
     },
     "ref_instrument": {
-      "type": "string",
-      "description": "Name of the reference mission or, instrument, ex. Fermi-GBM"
+      "description": "Name of the reference mission or, instrument, ex. Fermi-GBM",
+      "type": "string"
     },
-    "ref_ID": {
-      "type": "string",
-      "description": "Trigger ID as reported by the reference instrument, ex. bnYYMMDDFF"
+    "ref_type": {
+      "description": "Type of the event detected, ex. GRB, GW, neutrino",
+      "type": "string"
     },
     "reference": {
+      "description": "Reference as distributed by the notices or circulars or ATel, ex. gcn circulars: 12345, gcn.notices.LVK.alert: SYYMMDDak-2-preliminary. ",
       "type": "object",
-      "additionalProperties": { "type": ["number", "string"] },
-      "description": "Reference as distributed by the notices or circulars or ATel, ex. gcn circulars: 12345, gcn.notices.LVK.alert: SYYMMDDak-2-preliminary. "
+      "additionalProperties": {
+        "type": [
+          "number",
+          "string"
+        ]
+      }
     }
   }
 }

--- a/gcn/notices/core/HardnessRatio.schema.json
+++ b/gcn/notices/core/HardnessRatio.schema.json
@@ -1,33 +1,39 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/HardnessRatio.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/HardnessRatio.schema.json",
   "title": "HardnessRatio",
   "description": "Hardness Ratio parameterization",
+  "type": "object",
   "properties": {
-    "hardness_ratio": {
-      "type": "number",
-      "description": "ratio of flux between high and low energy bands"
-    },
-    "hardness_ratio_error": {
+    "energy_range_hard": {
+      "description": "Energy range [keV] used in hard band of hardness ratio",
       "type": "array",
-      "items": { "type": "number" },
       "maxItems": 2,
-      "description": "ratio of flux between high and low energy bands, with asymmetric statistical errors taken into account"
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
     },
     "energy_range_soft": {
-      "type": "array",
-      "items": { "type": "number" },
       "description": "Energy range [keV] used in soft band of hardness ratio",
-      "minItems": 2,
-      "maxItems": 2
-    },
-    "energy_range_hard": {
       "type": "array",
-      "items": { "type": "number" },
-      "description": "Energy range [keV] used in hard band of hardness ratio",
+      "maxItems": 2,
       "minItems": 2,
-      "maxItems": 2
+      "items": {
+        "type": "number"
+      }
+    },
+    "hardness_ratio": {
+      "description": "ratio of flux between high and low energy bands",
+      "type": "number"
+    },
+    "hardness_ratio_error": {
+      "description": "ratio of flux between high and low energy bands, with asymmetric statistical errors taken into account",
+      "type": "array",
+      "maxItems": 2,
+      "items": {
+        "type": "number"
+      }
     }
   }
 }

--- a/gcn/notices/core/Localization.schema.json
+++ b/gcn/notices/core/Localization.schema.json
@@ -1,64 +1,66 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Localization.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Localization.schema.json",
   "title": "Localization",
   "description": "Localization of transient",
+  "type": "object",
   "properties": {
-    "ra": {
-      "type": "number",
-      "description": "ICRS right ascension [deg], utilizes the J2000 epoch and an equatorial coordinate system"
+    "containment_probability": {
+      "description": "Containment probability [dimensionless, 0-1]; if absent, default is 0.9",
+      "default": 0.9,
+      "type": "number"
     },
     "dec": {
-      "type": "number",
-      "description": "ICRS declination [deg], utilizes the J2000 epoch and an equatorial coordinate system"
+      "description": "ICRS declination [deg], utilizes the J2000 epoch and an equatorial coordinate system",
+      "type": "number"
+    },
+    "healpix_file": {
+      "description": "Base 64 encoded content of a FITS file",
+      "type": "string",
+      "contentEncoding": "base64",
+      "contentMediaType": "image/fits"
+    },
+    "healpix_url": {
+      "description": "URL of HEALPix localization probability file",
+      "type": "string"
+    },
+    "instrument_phi": {
+      "description": "Instrument phi [deg]",
+      "type": "number"
+    },
+    "instrument_semimajor_angle": {
+      "description": "Position angle of semi-major axis in instrument coordinates [deg]",
+      "type": "number"
+    },
+    "instrument_theta": {
+      "description": "Instrument theta [deg]",
+      "type": "number"
+    },
+    "ra": {
+      "description": "ICRS right ascension [deg], utilizes the J2000 epoch and an equatorial coordinate system",
+      "type": "number"
     },
     "ra_dec_error": {
       "anyOf": [
         {
-          "type": "number",
-          "description": "Uncertainty region described as a circle with a radius [deg]."
+          "description": "Uncertainty region described as a circle with a radius [deg].",
+          "type": "number"
         },
         {
+          "description": "An array of up to three values that describe the localization region as an ellipse: length of the semi-major axis, length of the semi-minor axis (default is the same as the semi-major axis), and astronomical position angle of the semi-major axis (measured from North through East, default is zero).",
           "type": "array",
-          "items": { "type": "number" },
-          "minItems": 1,
           "maxItems": 3,
-          "description": "An array of up to three values that describe the localization region as an ellipse: length of the semi-major axis, length of the semi-minor axis (default is the same as the semi-major axis), and astronomical position angle of the semi-major axis (measured from North through East, default is zero)."
+          "minItems": 1,
+          "items": {
+            "type": "number"
+          }
         }
       ]
     },
-    "containment_probability": {
-      "type": "number",
-      "description": "Containment probability [dimensionless, 0-1]; if absent, default is 0.9",
-      "default": 0.9
-    },
     "systematic_included": {
-      "type": "boolean",
       "description": "Contains true when the systematic error is included and false when the systematic error is not included",
-      "default": false
-    },
-    "instrument_phi": {
-      "type": "number",
-      "description": "Instrument phi [deg]"
-    },
-    "instrument_theta": {
-      "type": "number",
-      "description": "Instrument theta [deg]"
-    },
-    "instrument_semimajor_angle": {
-      "type": "number",
-      "description": "Position angle of semi-major axis in instrument coordinates [deg]"
-    },
-    "healpix_url": {
-      "type": "string",
-      "description": "URL of HEALPix localization probability file"
-    },
-    "healpix_file": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "contentMediaType": "image/fits",
-      "description": "Base 64 encoded content of a FITS file"
+      "default": false,
+      "type": "boolean"
     }
   }
 }

--- a/gcn/notices/core/Orbit.schema.json
+++ b/gcn/notices/core/Orbit.schema.json
@@ -1,26 +1,29 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/GeoLocBase.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/GeoLocBase.schema.json",
   "title": "Spacecraft Geolocation and McIlwain L",
   "description": "Enables GCN providers to include spacecraft geolocation and McIlwain L-Parameter.",
   "type": "object",
   "properties": {
+    "altitude": {
+      "description": "Distance from the surface of the Earth [km].",
+      "type": "number"
+    },
+    "geoloc_time": {
+      "description": "Time [UTC, ISO 8601] of the geolocation and McIlwain L-parameter, if different than the trigger time.",
+      "type": "string"
+    },
     "latitude": {
-      "type": "number",
-      "description": "Geocentric latitude [deg]"
+      "description": "Geocentric latitude [deg]",
+      "type": "number"
     },
     "longitude": {
-      "type": "number",
-      "description": "Geocentric longitude [deg]"
+      "description": "Geocentric longitude [deg]",
+      "type": "number"
     },
-    "altitude": {
-      "type": "number",
-      "description": "Distance from the surface of the Earth [km]."
-    },
-    "mcilwain_l": { "type": "number", "description": "McIlwain L-parameter" },
-    "geoloc_time": {
-      "type": "string",
-      "description": "Time [UTC, ISO 8601] of the geolocation and McIlwain L-parameter, if different than the trigger time."
+    "mcilwain_l": {
+      "description": "McIlwain L-parameter",
+      "type": "number"
     }
   }
 }

--- a/gcn/notices/core/Pointing.schema.json
+++ b/gcn/notices/core/Pointing.schema.json
@@ -1,44 +1,48 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Pointing.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Pointing.schema.json",
   "title": "Instrument Pointing",
   "description": "Instrument pointing and rotational rates.",
   "$comment": "Providers should $ref this schema directly but Attitudes.schema.json instead.",
   "type": "object",
   "properties": {
-    "ra": {
-      "type": "number",
-      "description": "RA pointing of the instrument Z axis"
+    "attitude_quarternion": {
+      "description": "Representing attitude state of a spacecraft, using four element vector [q1, q2, q3, q4], composed of a scalar and 3 element unit vector.",
+      "type": "array",
+      "maxItems": 4,
+      "minItems": 4,
+      "items": {
+        "type": "number"
+      }
     },
     "dec": {
-      "type": "number",
-      "description": "Dec pointing of the instrument Z axis"
-    },
-    "roll": {
-      "type": "number",
-      "description": "Roll [deg] of the instrument about its Z axis"
+      "description": "Dec pointing of the instrument Z axis",
+      "type": "number"
     },
     "position_angle": {
-      "type": "number",
-      "description": "Rotation angle [deg] between the spacecraft X-Z plane and the plane defined by the spacecraft X-axis and celestial North"
+      "description": "Rotation angle [deg] between the spacecraft X-Z plane and the plane defined by the spacecraft X-axis and celestial North",
+      "type": "number"
     },
-    "attitude_quarternion": {
-      "type": "array",
-      "items": { "type": "number" },
-      "minItems": 4,
-      "maxItems": 4,
-      "description": "Representing attitude state of a spacecraft, using four element vector [q1, q2, q3, q4], composed of a scalar and 3 element unit vector."
+    "ra": {
+      "description": "RA pointing of the instrument Z axis",
+      "type": "number"
+    },
+    "roll": {
+      "description": "Roll [deg] of the instrument about its Z axis",
+      "type": "number"
     },
     "rotation_rate": {
+      "description": "Rotational rate [rad/s] about the X, Y, and Z axes respectively",
       "type": "array",
-      "items": { "type": "number" },
-      "minItems": 3,
       "maxItems": 3,
-      "description": "Rotational rate [rad/s] about the X, Y, and Z axes respectively"
+      "minItems": 3,
+      "items": {
+        "type": "number"
+      }
     },
     "time": {
-      "type": "string",
-      "description": "Time [UTC, ISO 8601] of this data, if different than the trigger time."
+      "description": "Time [UTC, ISO 8601] of this data, if different than the trigger time.",
+      "type": "string"
     }
   }
 }

--- a/gcn/notices/core/Redshift.schema.json
+++ b/gcn/notices/core/Redshift.schema.json
@@ -1,21 +1,34 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Redshift.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Redshift.schema.json",
   "title": "Redshift",
   "description": "Redshift measure of transient",
+  "type": "object",
   "properties": {
     "redshift": {
-      "type": "number",
-      "description": "Displacement of spectral lines toward longer wavelengths [sigma]"
+      "description": "Displacement of spectral lines toward longer wavelengths [sigma]",
+      "type": "number"
     },
     "redshift_error": {
+      "description": "Error in redshift, array for asymmetric statistical errors",
       "type": "array",
-      "items": { "type": "number" },
       "maxItems": 2,
-      "description": "Error in redshift, array for asymmetric statistical errors"
+      "items": {
+        "type": "number"
+      }
     },
-    "redshift_measure": { "enum": ["spectroscopic", "photometric"] },
-    "redshift_type": { "enum": ["emission", "absorption", "host"] }
+    "redshift_measure": {
+      "enum": [
+        "spectroscopic",
+        "photometric"
+      ]
+    },
+    "redshift_type": {
+      "enum": [
+        "emission",
+        "absorption",
+        "host"
+      ]
+    }
   }
 }

--- a/gcn/notices/core/Reporter.schema.json
+++ b/gcn/notices/core/Reporter.schema.json
@@ -1,42 +1,54 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Reporter.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Reporter.schema.json",
   "title": "Reporter",
   "description": "Alert Reporter instrument",
   "type": "object",
   "properties": {
-    "mission": {
-      "type": "string",
-      "description": "Name of Mission or Telescope reporting the event"
+    "filter": {
+      "description": "Optional filter name, as used in optical observations",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "instrument": {
-      "type": "string",
-      "description": "Name of the Instrument reporting the event"
-    },
-    "record_number": {
-      "type": "number",
-      "description": "Incremental number for messages from the instrument during a given trigger (ex: 1, 2, 3)"
+      "description": "Name of the Instrument reporting the event",
+      "type": "string"
     },
     "messenger": {
-      "enum": ["EM", "GW", "Neutrino"],
-      "description": "Messenger of report; EM, GW or Neutrino"
+      "description": "Messenger of report; EM, GW or Neutrino",
+      "enum": [
+        "EM",
+        "GW",
+        "Neutrino"
+      ]
+    },
+    "mission": {
+      "description": "Name of Mission or Telescope reporting the event",
+      "type": "string"
+    },
+    "record_number": {
+      "description": "Incremental number for messages from the instrument during a given trigger (ex: 1, 2, 3)",
+      "type": "number"
     },
     "spectrum": {
-      "enum": ["energy", "wavelength", "frequency"],
       "description": "high-energy or optical or radio observations, if not parsed, then default band is energy",
-      "type": "string",
-      "default": "energy"
+      "default": "energy",
+      "enum": [
+        "energy",
+        "wavelength",
+        "frequency"
+      ]
     },
     "units": {
-      "enum": ["keV", "nm", "Hz"],
       "description": "Units of band range, if not parsed, then default energy is keV",
-      "type": "string",
-      "default": "keV"
-    },
-    "filter": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Optional filter name, as used in optical observations"
+      "default": "keV",
+      "enum": [
+        "keV",
+        "nm",
+        "Hz"
+      ]
     }
   }
 }

--- a/gcn/notices/core/Statistics.schema.json
+++ b/gcn/notices/core/Statistics.schema.json
@@ -1,69 +1,80 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Statistics.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/Statistics.schema.json",
   "title": "Statistics",
   "description": "statistical measures of source significance or classification",
+  "type": "object",
   "properties": {
-    "far": {
-      "type": "number",
-      "description": "False alarm rate: the rate of occurrence of non-astrophysical events that are of the same intensity or significance as the current event [Hz]"
-    },
-    "trigger_type": {
-      "enum": ["rate", "image"],
-      "description": "Type of trigger algorithm used to identify the transient event."
-    },
-    "net_count_rate": {
-      "type": "number",
-      "description": "Net count rate of the transient above the background [counts/s] over rate_duration and rate_energy_range. Do specify rate_duration and rate_energy_range with net_count_rate property."
+    "properties": {
+      "description": "Dictionary of binary classifiers, each entry is between 0 and 1. e.g. ({'NS', 0.95}, {'REMNANT', 0.3})",
+      "type": "object",
+      "additionalProperties": {
+        "type": "number"
+      }
     },
     "backgound_count_rate": {
-      "type": "number",
-      "description": "Count rate of the background during the transient [counts/s] over same rate_duration and rate_energy_range used for net_count_rate."
-    },
-    "rate_snr": {
-      "type": "number",
-      "description": "Rate signal to noise ratio [dimensionless]"
-    },
-    "rate_duration": {
-      "type": "number",
-      "description": "Interval over rate signal to noise ratio calculation [s]"
-    },
-    "rate_energy_range": {
-      "type": "array",
-      "items": { "type": "number" },
-      "minItems": 2,
-      "maxItems": 2,
-      "description": "Low and High energy bounds used in rate signal to noise ratio calculation, if not parsed in Reporter.schema.json, default unit is keV"
-    },
-    "image_snr": {
-      "type": "number",
-      "description": "Image signal to noise ratio [dimensionless]"
-    },
-    "image_duration": {
-      "type": "number",
-      "description": "Interval over image signal to noise ratio calculation [s]"
-    },
-    "image_energy_range": {
-      "type": "array",
-      "items": { "type": "number" },
-      "minItems": 2,
-      "maxItems": 2,
-      "description": "Low and High energy bounds used in image signal to noise ratio calculation, if not parsed in Reporter.schema.json, default unit is keV"
-    },
-    "p_astro": {
-      "type": "number",
-      "description": "Probability [dimensionless, 0-1] that source is of astrophysical origin"
+      "description": "Count rate of the background during the transient [counts/s] over same rate_duration and rate_energy_range used for net_count_rate.",
+      "type": "number"
     },
     "classification": {
+      "description": "Dictionary mapping mutually exclusive source classes to probabilities between 0 and 1, the sum of all values must be 1. e.g. ({'BNS', 0.9}, {'NSBH', 0.05}, {'BBH', 0.05})",
       "type": "object",
-      "additionalProperties": { "type": "number" },
-      "description": "Dictionary mapping mutually exclusive source classes to probabilities between 0 and 1, the sum of all values must be 1. e.g. ({'BNS', 0.9}, {'NSBH', 0.05}, {'BBH', 0.05})"
+      "additionalProperties": {
+        "type": "number"
+      }
     },
-    "properties": {
-      "type": "object",
-      "additionalProperties": { "type": "number" },
-      "description": "Dictionary of binary classifiers, each entry is between 0 and 1. e.g. ({'NS', 0.95}, {'REMNANT', 0.3})"
+    "far": {
+      "description": "False alarm rate: the rate of occurrence of non-astrophysical events that are of the same intensity or significance as the current event [Hz]",
+      "type": "number"
+    },
+    "image_duration": {
+      "description": "Interval over image signal to noise ratio calculation [s]",
+      "type": "number"
+    },
+    "image_energy_range": {
+      "description": "Low and High energy bounds used in image signal to noise ratio calculation, if not parsed in Reporter.schema.json, default unit is keV",
+      "type": "array",
+      "maxItems": 2,
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "image_snr": {
+      "description": "Image signal to noise ratio [dimensionless]",
+      "type": "number"
+    },
+    "net_count_rate": {
+      "description": "Net count rate of the transient above the background [counts/s] over rate_duration and rate_energy_range. Do specify rate_duration and rate_energy_range with net_count_rate property.",
+      "type": "number"
+    },
+    "p_astro": {
+      "description": "Probability [dimensionless, 0-1] that source is of astrophysical origin",
+      "type": "number"
+    },
+    "rate_duration": {
+      "description": "Interval over rate signal to noise ratio calculation [s]",
+      "type": "number"
+    },
+    "rate_energy_range": {
+      "description": "Low and High energy bounds used in rate signal to noise ratio calculation, if not parsed in Reporter.schema.json, default unit is keV",
+      "type": "array",
+      "maxItems": 2,
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "rate_snr": {
+      "description": "Rate signal to noise ratio [dimensionless]",
+      "type": "number"
+    },
+    "trigger_type": {
+      "description": "Type of trigger algorithm used to identify the transient event.",
+      "enum": [
+        "rate",
+        "image"
+      ]
     }
   }
 }

--- a/gcn/notices/core/spectral/GammaRay.schema.json
+++ b/gcn/notices/core/spectral/GammaRay.schema.json
@@ -1,92 +1,111 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/spectral/GammaRay.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/spectral/GammaRay.schema.json",
   "title": "spectral.GammaRay",
   "description": "Spectral properties from gamma-ray data",
+  "type": "object",
   "properties": {
-    "best_fit_model": {
-      "enum": ["POWERLAW", "CUTOFFPOWERLAW", "BAND"],
-      "description": "Name of model corresponding to best statistical fit of spectrum"
+    "band": {
+      "description": "Fit parameters for Band model",
+      "$ref": "./models/Band.schema.json"
     },
-    "power_law": {
-      "$ref": "./models/PowerLaw.schema.json",
-      "description": "Fit parameters for PowerLaw model"
+    "best_fit_model": {
+      "description": "Name of model corresponding to best statistical fit of spectrum",
+      "enum": [
+        "POWERLAW",
+        "CUTOFFPOWERLAW",
+        "BAND"
+      ]
     },
     "cutoff_power_law": {
-      "$ref": "./models/CutOffPowerLaw.schema.json",
-      "description": "Fit parameters for Cutoff PowerLaw model"
-    },
-    "band": {
-      "$ref": "./models/Band.schema.json",
-      "description": "Fit parameters for Band model"
-    },
-    "spectral_energy_range": {
-      "type": "array",
-      "items": { "type": "number" },
-      "minItems": 2,
-      "maxItems": 2,
-      "description": "Low and High energy bounds used in spectral fit, if not parsed in Reporter.schema.json, default unit is keV"
-    },
-    "hardness_ratio": {
-      "type": "number",
-      "description": "ratio of flux between high and low energy bands"
-    },
-    "hardness_ratio_energy_range": {
-      "type": "array",
-      "items": { "type": "number" },
-      "minItems": 2,
-      "maxItems": 2,
-      "description": "Low and High energy bounds used for hardness ratio, if not parsed in Reporter.schema.json, default unit is keV"
-    },
-    "photon_flux": {
-      "type": "number",
-      "description": "Photon Flux [ph/cm2/s]"
-    },
-    "photon_flux_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty in Photon Flux [ph/cm2/s]"
+      "description": "Fit parameters for Cutoff PowerLaw model",
+      "$ref": "./models/CutOffPowerLaw.schema.json"
     },
     "energy_flux": {
-      "type": "number",
-      "description": "Energy Flux [erg/cm2/s]"
+      "description": "Energy Flux [erg/cm2/s]",
+      "type": "number"
     },
     "energy_flux_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty in Energy Flux [erg/cm2/s]"
+      "description": "1-sigma uncertainty in Energy Flux [erg/cm2/s]",
+      "type": "number"
     },
-    "flux_energy_range": {
-      "type": "array",
-      "items": { "type": "number" },
-      "minItems": 2,
-      "maxItems": 2,
-      "description": "Low and High energy bounds used in flux calculation, if not parsed in Reporter.schema.json, default unit is keV"
-    },
-    "flux_time_range": {
-      "type": "array",
-      "items": { "type": "number" },
-      "minItems": 2,
-      "maxItems": 2,
-      "description": "Start and stop time stamps in array as used in flux calculation, measured since trigger [s]"
-    },
-    "fluence": { "type": "number", "description": "Fluence [erg/cm2]" },
-    "fluence_error": {
-      "type": "number",
-      "description": "Fluence Error [erg/cm2]"
+    "fluence": {
+      "description": "Fluence [erg/cm2]",
+      "type": "number"
     },
     "fluence_energy_range": {
+      "description": "Low and High energy bounds used in fluence calculation, if not parsed in Reporter.schema.json, default unit is keV",
       "type": "array",
-      "items": { "type": "number" },
-      "minItems": 2,
       "maxItems": 2,
-      "description": "Low and High energy bounds used in fluence calculation, if not parsed in Reporter.schema.json, default unit is keV"
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "fluence_error": {
+      "description": "Fluence Error [erg/cm2]",
+      "type": "number"
     },
     "fluence_time_range": {
+      "description": "Start and stop time stamps in array as used in fluence calculation, measured since trigger [s]",
       "type": "array",
-      "items": { "type": "number" },
-      "minItems": 2,
       "maxItems": 2,
-      "description": "Start and stop time stamps in array as used in fluence calculation, measured since trigger [s]"
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "flux_energy_range": {
+      "description": "Low and High energy bounds used in flux calculation, if not parsed in Reporter.schema.json, default unit is keV",
+      "type": "array",
+      "maxItems": 2,
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "flux_time_range": {
+      "description": "Start and stop time stamps in array as used in flux calculation, measured since trigger [s]",
+      "type": "array",
+      "maxItems": 2,
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "hardness_ratio": {
+      "description": "ratio of flux between high and low energy bands",
+      "type": "number"
+    },
+    "hardness_ratio_energy_range": {
+      "description": "Low and High energy bounds used for hardness ratio, if not parsed in Reporter.schema.json, default unit is keV",
+      "type": "array",
+      "maxItems": 2,
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "photon_flux": {
+      "description": "Photon Flux [ph/cm2/s]",
+      "type": "number"
+    },
+    "photon_flux_error": {
+      "description": "1-sigma uncertainty in Photon Flux [ph/cm2/s]",
+      "type": "number"
+    },
+    "power_law": {
+      "description": "Fit parameters for PowerLaw model",
+      "$ref": "./models/PowerLaw.schema.json"
+    },
+    "spectral_energy_range": {
+      "description": "Low and High energy bounds used in spectral fit, if not parsed in Reporter.schema.json, default unit is keV",
+      "type": "array",
+      "maxItems": 2,
+      "minItems": 2,
+      "items": {
+        "type": "number"
+      }
     }
   }
 }

--- a/gcn/notices/core/spectral/models/Band.schema.json
+++ b/gcn/notices/core/spectral/models/Band.schema.json
@@ -1,42 +1,45 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/spectral/models/Band.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/spectral/models/Band.schema.json",
   "title": "Band",
   "description": "Spectral model Band smoothly broken powerlaw (Band et al. 1993)",
+  "type": "object",
   "properties": {
-    "amplitude": {
-      "type": "number",
-      "description": "amplitude of spectral model fit at pivot_energy [ph/cm2/s/keV]"
-    },
-    "amplitude_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of amplitude [ph/cm2/s/keV]"
-    },
-    "pivot_energy": { "type": "number", "description": "pivot energy [keV]" },
     "alpha": {
-      "type": "number",
-      "description": "power-law index of spectral model"
+      "description": "power-law index of spectral model",
+      "type": "number"
     },
     "alpha_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of alpha"
+      "description": "1-sigma uncertainty of alpha",
+      "type": "number"
     },
-    "epeak": {
-      "type": "number",
-      "description": "e-folding energy of exponential rolloff [keV]"
+    "amplitude": {
+      "description": "amplitude of spectral model fit at pivot_energy [ph/cm2/s/keV]",
+      "type": "number"
     },
-    "epeak_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of Epeak [keV]"
+    "amplitude_error": {
+      "description": "1-sigma uncertainty of amplitude [ph/cm2/s/keV]",
+      "type": "number"
     },
     "beta": {
-      "type": "number",
-      "description": "high-energy power-law index of Band parameterization"
+      "description": "high-energy power-law index of Band parameterization",
+      "type": "number"
     },
     "beta_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of beta"
+      "description": "1-sigma uncertainty of beta",
+      "type": "number"
+    },
+    "epeak": {
+      "description": "e-folding energy of exponential rolloff [keV]",
+      "type": "number"
+    },
+    "epeak_error": {
+      "description": "1-sigma uncertainty of Epeak [keV]",
+      "type": "number"
+    },
+    "pivot_energy": {
+      "description": "pivot energy [keV]",
+      "type": "number"
     }
   }
 }

--- a/gcn/notices/core/spectral/models/CutOffPowerLaw.schema.json
+++ b/gcn/notices/core/spectral/models/CutOffPowerLaw.schema.json
@@ -1,34 +1,37 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/spectral/models/CutOffPowerLaw.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/spectral/models/CutOffPowerLaw.schema.json",
   "title": "CutOffPowerLaw",
   "description": "Spectral model known as comptonized or powerlaw with exponential cutoff amplitude*energy^{-alpha}*exp(-energy/beta)",
+  "type": "object",
   "properties": {
-    "amplitude": {
-      "type": "number",
-      "description": "amplitude of spectral model fit at pivot_energy [ph/cm2/s/keV]"
-    },
-    "amplitude_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of amplitude [ph/cm2/s/keV]"
-    },
-    "pivot_energy": { "type": "number", "description": "pivot energy [keV]" },
     "alpha": {
-      "type": "number",
-      "description": "power-law index of spectral model"
+      "description": "power-law index of spectral model",
+      "type": "number"
     },
     "alpha_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of alpha"
+      "description": "1-sigma uncertainty of alpha",
+      "type": "number"
+    },
+    "amplitude": {
+      "description": "amplitude of spectral model fit at pivot_energy [ph/cm2/s/keV]",
+      "type": "number"
+    },
+    "amplitude_error": {
+      "description": "1-sigma uncertainty of amplitude [ph/cm2/s/keV]",
+      "type": "number"
     },
     "epeak": {
-      "type": "number",
-      "description": "e-folding energy of exponential rolloff [keV]"
+      "description": "e-folding energy of exponential rolloff [keV]",
+      "type": "number"
     },
     "epeak_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of Epeak [keV]"
+      "description": "1-sigma uncertainty of Epeak [keV]",
+      "type": "number"
+    },
+    "pivot_energy": {
+      "description": "pivot energy [keV]",
+      "type": "number"
     }
   }
 }

--- a/gcn/notices/core/spectral/models/PowerLaw.schema.json
+++ b/gcn/notices/core/spectral/models/PowerLaw.schema.json
@@ -1,26 +1,29 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/spectral/models/PowerLaw.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/core/spectral/models/PowerLaw.schema.json",
   "title": "PowerLaw",
   "description": "Spectral model powerlaw with N(E)=amplitude*energy^{-alpha}",
+  "type": "object",
   "properties": {
-    "amplitude": {
-      "type": "number",
-      "description": "amplitude of spectral model fit at pivot_energy [ph/cm2/s/keV]"
-    },
-    "amplitude_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of amplitude [ph/cm2/s/keV]"
-    },
-    "pivot_energy": { "type": "number", "description": "pivot energy [keV]" },
     "alpha": {
-      "type": "number",
-      "description": "power-law index of spectral model"
+      "description": "power-law index of spectral model",
+      "type": "number"
     },
     "alpha_error": {
-      "type": "number",
-      "description": "1-sigma uncertainty of alpha"
+      "description": "1-sigma uncertainty of alpha",
+      "type": "number"
+    },
+    "amplitude": {
+      "description": "amplitude of spectral model fit at pivot_energy [ph/cm2/s/keV]",
+      "type": "number"
+    },
+    "amplitude_error": {
+      "description": "1-sigma uncertainty of amplitude [ph/cm2/s/keV]",
+      "type": "number"
+    },
+    "pivot_energy": {
+      "description": "pivot energy [keV]",
+      "type": "number"
     }
   }
 }

--- a/gcn/notices/einstein_probe/wxt/alert.schema.json
+++ b/gcn/notices/einstein_probe/wxt/alert.schema.json
@@ -1,14 +1,24 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/einstein_probe/wxt/alert.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/einstein_probe/wxt/alert.schema.json",
   "title": "EP/WXT Alert",
   "description": "Candidate X-ray transient reported from the EP/WXT on board trigger",
   "type": "object",
   "allOf": [
-    { "$ref": "../../core/DateTime.schema.json" },
-    { "$ref": "../../core/Localization.schema.json" },
-    { "$ref": "../../core/Reporter.schema.json" },
-    { "$ref": "../../core/Statistics.schema.json" },
-    { "$ref": "../../core/AdditionalInfo.schema.json" }
+    {
+      "$ref": "../../core/DateTime.schema.json"
+    },
+    {
+      "$ref": "../../core/Localization.schema.json"
+    },
+    {
+      "$ref": "../../core/Reporter.schema.json"
+    },
+    {
+      "$ref": "../../core/Statistics.schema.json"
+    },
+    {
+      "$ref": "../../core/AdditionalInfo.schema.json"
+    }
   ]
 }

--- a/gcn/notices/glowbug/Alert.schema.json
+++ b/gcn/notices/glowbug/Alert.schema.json
@@ -1,51 +1,83 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/glowbug/alert.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/glowbug/alert.schema.json",
   "title": "Glowbug Alert Notice",
   "description": "Information about a Glowbug trigger.  All fields optional; omitted if not available or not applicable.",
   "type": "object",
   "allOf": [
     {
-      "$ref": "../core/Reporter.schema.json",
-      "description": "mission=GLOWBUG"
+      "description": "mission=GLOWBUG",
+      "$ref": "../core/Reporter.schema.json"
     },
     {
-      "$ref": "../core/AdditionalInfo.schema.json",
-      "description": "Complementary info in text form."
-    },
-    { "$ref": "../core/Alert.schema.json" },
-    {
-      "$ref": "../core/Event.schema.json",
-      "description": "event_id=[ 'BUGyymmdd.fff', seqnum ], where fff is in millidays with trailing zeros. id_source=GLOWBUG for both."
+      "description": "Complementary info in text form.",
+      "$ref": "../core/AdditionalInfo.schema.json"
     },
     {
-      "$ref": "../core/DateTime.schema.json",
-      "description": "Trigger_time with seconds fraction."
+      "$ref": "../core/Alert.schema.json"
     },
     {
-      "$ref": "../core/Statistics.schema.json",
-      "description": "rate_duration is the integration time (a.k.a. trigger time scale), over which the rate_snr was measured."
+      "description": "event_id=[ 'BUGyymmdd.fff', seqnum ], where fff is in millidays with trailing zeros. id_source=GLOWBUG for both.",
+      "$ref": "../core/Event.schema.json"
+    },
+    {
+      "description": "Trigger_time with seconds fraction.",
+      "$ref": "../core/DateTime.schema.json"
+    },
+    {
+      "description": "rate_duration is the integration time (a.k.a. trigger time scale), over which the rate_snr was measured.",
+      "$ref": "../core/Statistics.schema.json"
     }
   ],
   "properties": {
     "detector_status": {
       "type": "object",
       "properties": {
-        "CsI0": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI1": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI2": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI3": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI4": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI5": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI6": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI7": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI8": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI9": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI10": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CsI11": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CLLB0": { "$ref": "../core/DetectorStatus.schema.json" },
-        "CLLB1": { "$ref": "../core/DetectorStatus.schema.json" },
-        "SSA": { "$ref": "../core/DetectorStatus.schema.json" }
+        "CLLB0": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CLLB1": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI0": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI1": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI10": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI11": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI2": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI3": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI4": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI5": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI6": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI7": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI8": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "CsI9": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        },
+        "SSA": {
+          "$ref": "../core/DetectorStatus.schema.json"
+        }
       }
     }
   }

--- a/gcn/notices/heasarc/archive_alert.schema.json
+++ b/gcn/notices/heasarc/archive_alert.schema.json
@@ -1,9 +1,9 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/heasarc/archive_alert.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/heasarc/archive_alert.schema.json",
   "title": "HEASARC - Data in Archive",
   "description": "Data Archived at HEASARC",
+  "type": "object",
   "allOf": [
     {
       "$ref": "../core/Alert.schema.json"
@@ -19,21 +19,21 @@
     }
   ],
   "properties": {
-    "obs_id": {
-      "type": "string",
-      "description": "The observation identifier of the sequence. Also called the observation id, sequence number, and seqnum, it is a series of numerical digits, each signifying different aspects for the observation, such as AO year, proposal number, and target number. Each mission has their own specification for how the obsid is defined. Every observation by an observatory is identified by the obsid. The data set identified by the obsid contains the level one and level 2 data created by that mission's processing pipeline. [Fields to align with IVOA ObsCore]"
-    },
-    "target_name": {
-      "type": "string",
-      "description": "Name of the target object for the observation [IVOA ObsCore]"
+    "facility_name": {
+      "description": "Name of the creator of the data [IVOA ObsCore]",
+      "type": "string"
     },
     "mission_page": {
-      "type": "string",
-      "description": "Web page of the creator mission at HEASARC"
+      "description": "Web page of the creator mission at HEASARC",
+      "type": "string"
     },
-    "facility_name": {
-      "type": "string",
-      "description": "Name of the creator of the data [IVOA ObsCore]"
+    "obs_id": {
+      "description": "The observation identifier of the sequence. Also called the observation id, sequence number, and seqnum, it is a series of numerical digits, each signifying different aspects for the observation, such as AO year, proposal number, and target number. Each mission has their own specification for how the obsid is defined. Every observation by an observatory is identified by the obsid. The data set identified by the obsid contains the level one and level 2 data created by that mission's processing pipeline. [Fields to align with IVOA ObsCore]",
+      "type": "string"
+    },
+    "target_name": {
+      "description": "Name of the target object for the observation [IVOA ObsCore]",
+      "type": "string"
     }
   }
 }

--- a/gcn/notices/icecube/lvk_nu_track_search.schema.json
+++ b/gcn/notices/icecube/lvk_nu_track_search.schema.json
@@ -1,83 +1,109 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/icecube/lvk_nu_track_search.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/icecube/lvk_nu_track_search.schema.json",
   "title": "IceCube LVK Alert Nu Track Search",
   "description": "IceCube LVK Coincident Neutrino Track Search",
+  "type": "object",
   "allOf": [
     {
-      "$ref": "../core/Alert.schema.json",
-      "description": "Alert information (alert_datetime and alert_type) from LVK alert notices"
+      "description": "Alert information (alert_datetime and alert_type) from LVK alert notices",
+      "$ref": "../core/Alert.schema.json"
     },
     {
-      "$ref": "../core/FollowUp.schema.json",
-      "description": "ID (ref_ID) of LVK alert notice"
+      "description": "ID (ref_ID) of LVK alert notice",
+      "$ref": "../core/FollowUp.schema.json"
     },
-    { "$ref": "../core/AdditionalInfo.schema.json" },
     {
-      "$ref": "../core/Reporter.schema.json",
-      "description": "Record/Sequence number of LVK alerts"
+      "$ref": "../core/AdditionalInfo.schema.json"
     },
-    { "$ref": "../core/DateTime.schema.json" }
+    {
+      "description": "Record/Sequence number of LVK alerts",
+      "$ref": "../core/Reporter.schema.json"
+    },
+    {
+      "$ref": "../core/DateTime.schema.json"
+    }
   ],
   "properties": {
-    "pval_generic": {
-      "description": "P-value from generic transient search; consistency with background expectations [0-1]",
-      "type": ["number", "null"]
-    },
-    "pval_bayesian": {
-      "description": "P-value from LLAMA Bayesian search; consistency with background expectations [0-1]",
-      "type": ["number", "null"]
-    },
-    "n_events_coincident": {
-      "description": "Number of IceCube events in spatial and temporal coincidence with the GW map",
-      "type": "number"
-    },
     "coincident_events": {
-      "type": "array",
       "description": "An array of summary of information for each coincident neutrino track event",
-      "items": { "$ref": "#/$defs/coincevent" }
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/coincevent"
+      }
     },
     "most_probable_direction": {
       "description": "Most likely source direction based on all coincident events and GW localizations",
       "$ref": "../core/Localization.schema.json"
     },
+    "n_events_coincident": {
+      "description": "Number of IceCube events in spatial and temporal coincidence with the GW map",
+      "type": "number"
+    },
     "neutrino_flux_sensitivity_range": {
       "description": "Time integrated flux sensitivity ranges assuming an E^-2 spectrum (E^2 dN/dE) within the GW map localization",
       "$ref": "#/$defs/fluxlimits"
+    },
+    "pval_bayesian": {
+      "description": "P-value from LLAMA Bayesian search; consistency with background expectations [0-1]",
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "pval_generic": {
+      "description": "P-value from generic transient search; consistency with background expectations [0-1]",
+      "type": [
+        "number",
+        "null"
+      ]
     }
   },
   "$defs": {
+    "coincevent": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "../core/Localization.schema.json"
+        }
+      ],
+      "properties": {
+        "event_dt": {
+          "description": "Time difference between LVK alert time and neutrino candidate [sec]",
+          "type": "number"
+        },
+        "event_pval_bayesian": {
+          "description": "Per-event P-value from LLAMA Bayesian search; consistency with background expectations [0-1]",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "event_pval_generic": {
+          "description": "Per-event P-value from generic transient search; consistency with background expectations [0-1]",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      }
+    },
     "fluxlimits": {
       "type": "object",
       "properties": {
         "flux_sensitivity": {
           "description": "Time integrated flux sensitivity range (min, max) [GeV cm^-2] assuming an E^-2 spectrum (E^2 dN/dE) found within the 90% region of GW map localization",
           "type": "array",
-          "items": { "type": "number" }
+          "items": {
+            "type": "number"
+          }
         },
         "sensitive_energy_range": {
           "description": "Energy sensitivity range (lower, upper) [GeV] assuming an E^-2 spectrum (E^2 dN/dE)",
           "type": "array",
-          "items": { "type": "number" }
-        }
-      }
-    },
-    "coincevent": {
-      "type": "object",
-      "allOf": [{ "$ref": "../core/Localization.schema.json" }],
-      "properties": {
-        "event_dt": {
-          "description": "Time difference between LVK alert time and neutrino candidate [sec]",
-          "type": "number"
-        },
-        "event_pval_generic": {
-          "description": "Per-event P-value from generic transient search; consistency with background expectations [0-1]",
-          "type": ["number", "null"]
-        },
-        "event_pval_bayesian": {
-          "description": "Per-event P-value from LLAMA Bayesian search; consistency with background expectations [0-1]",
-          "type": ["number", "null"]
+          "items": {
+            "type": "number"
+          }
         }
       }
     }

--- a/gcn/notices/icecube/test/gold_bronze_track_alerts.schema.json
+++ b/gcn/notices/icecube/test/gold_bronze_track_alerts.schema.json
@@ -1,16 +1,28 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/icecube/test/gold_bronze_track_alerts.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/icecube/test/gold_bronze_track_alerts.schema.json",
   "title": "IceCubeGoldAndBronzeTracks",
   "description": "IceCube Astrotrack Gold And Bronze track alert events",
+  "type": "object",
   "allOf": [
-    { "$ref": "../../core/AdditionalInfo.schema.json" },
-    { "$ref": "../../core/Event.schema.json" },
-    { "$ref": "../../core/Alert.schema.json" },
-    { "$ref": "../../core/Localization.schema.json" },
-    { "$ref": "../../core/DateTime.schema.json" },
-    { "$ref": "../../core/Statistics.schema.json" }
+    {
+      "$ref": "../../core/AdditionalInfo.schema.json"
+    },
+    {
+      "$ref": "../../core/Event.schema.json"
+    },
+    {
+      "$ref": "../../core/Alert.schema.json"
+    },
+    {
+      "$ref": "../../core/Localization.schema.json"
+    },
+    {
+      "$ref": "../../core/DateTime.schema.json"
+    },
+    {
+      "$ref": "../../core/Statistics.schema.json"
+    }
   ],
   "properties": {
     "nu_energy": {

--- a/gcn/notices/swift/bat/Guano.schema.json
+++ b/gcn/notices/swift/bat/Guano.schema.json
@@ -1,27 +1,41 @@
 {
-  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/swift/bat/guano.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcn.nasa.gov/schema/main/gcn/notices/swift/bat/guano.schema.json",
   "title": "Swift/BAT-GUANO Alert",
   "description": "Candidate gamma-ray transient reported from the BAT-GUANO targeted search",
   "type": "object",
   "allOf": [
-    { "$ref": "../../core/Alert.schema.json" },
-    { "$ref": "../../core/Event.schema.json" },
-    { "$ref": "../../core/DateTime.schema.json" },
-    { "$ref": "../../core/Localization.schema.json" },
-    { "$ref": "../../core/Statistics.schema.json" },
-    { "$ref": "../../core/Reporter.schema.json" },
-    { "$ref": "../../core/AdditionalInfo.schema.json" }
+    {
+      "$ref": "../../core/Alert.schema.json"
+    },
+    {
+      "$ref": "../../core/Event.schema.json"
+    },
+    {
+      "$ref": "../../core/DateTime.schema.json"
+    },
+    {
+      "$ref": "../../core/Localization.schema.json"
+    },
+    {
+      "$ref": "../../core/Statistics.schema.json"
+    },
+    {
+      "$ref": "../../core/Reporter.schema.json"
+    },
+    {
+      "$ref": "../../core/AdditionalInfo.schema.json"
+    }
   ],
   "properties": {
     "$schema": true,
     "follow_up_event": {
-      "type": "string",
-      "description": "Name or trigger time of the external trigger that launched the search."
+      "description": "Name or trigger time of the external trigger that launched the search.",
+      "type": "string"
     },
     "follow_up_type": {
-      "type": "string",
-      "description": "Type of external trigger that launched the search, eg GW, neutrino, etc."
+      "description": "Type of external trigger that launched the search, eg GW, neutrino, etc.",
+      "type": "string"
     }
   },
   "unevaluatedProperties": false


### PR DESCRIPTION
Hey there! This is a PR to mainly start a conversation. I'm a member of JSON Schema organization involved in maintaining various JSON Schema related tooling (like https://alterschema.sourcemeta.com) and documentation (like https://www.learnjsonschema.com), plus co-author of the recently published O'Reilly book touching on JSON Schema (https://www.oreilly.com/library/view/unifying-business-data/9781098144999/).

Based on our experience working with organizations maintaining repositories of schemas (like you!), we've been working on an open-source CLI tool that aims to simplify development and CI/CD when dealing with schemas. This CLI supports a growing amount of commands, but I'm proposing two for this repository to start with:

- Formatting: making sure your schemas following a consistent style (i.e. indentation) plus a consistent ordering of keywords that was designed to make schemas easier to read

- Linting: we are collecting common rules to highlight anti-patterns, common pitfalls, etc when using JSON Schema. There are not that many implement out there, but the linter already caught a little anti-pattern in `Reporter`: setting `enum` alongside `type`

I would love to hear your feedback, feature requests, etc to help you make better use of JSON Schema with this CLI! We also have other things on the way, like a proper JSON Schema test runner that could eventually simplify your AJV scripts!