### PR TITLE
Add EP event name

### DIFF
--- a/gcn/notices/einstein_probe/wxt/alert.example.json
+++ b/gcn/notices/einstein_probe/wxt/alert.example.json
@@ -2,6 +2,7 @@
   "$schema": "https://gcn.nasa.gov/schema/main/gcn/notices/einstein_probe/wxt/alert.schema.json",
   "instrument": "WXT",
   "trigger_time": "2024-03-01T21:46:05.13Z",
+  "event_name": ["EP240618a"],
   "ra": 120,
   "dec": 40,
   "ra_dec_error": 0.02,

--- a/gcn/notices/einstein_probe/wxt/alert.schema.json
+++ b/gcn/notices/einstein_probe/wxt/alert.schema.json
@@ -6,6 +6,7 @@
   "type": "object",
   "allOf": [
     { "$ref": "../../core/DateTime.schema.json" },
+    { "$ref": "../../core/Event.schema.json" },
     { "$ref": "../../core/Localization.schema.json" },
     { "$ref": "../../core/Reporter.schema.json" },
     { "$ref": "../../core/Statistics.schema.json" },


### PR DESCRIPTION
# Description
Following the Zendesk ticket #210 (https://nasa-gcn.zendesk.com/agent/tickets/210): 
The same event is being notified through both Notices and Circulars. However, they don't contain a common unique ID and have slightly different times and localization (as Circulars are more refined). 

It is necessary to include a property such as the event name or trigger ID as a unique ID, which should be the same across both Notices and Circulars. 
One potential option is the event name, which is currently reported in EP Circulars, and request to add it to the Notices pipeline. 

@modot, please check what's more convenient at your end, either include the trigger ID or event name in the EP Notices.

