### PR TITLE
Add EP trigger id

### DIFF
--- a/gcn/notices/einstein_probe/wxt/alert.example.json
+++ b/gcn/notices/einstein_probe/wxt/alert.example.json
@@ -2,6 +2,7 @@
   "$schema": "https://gcn.nasa.gov/schema/main/gcn/notices/einstein_probe/wxt/alert.schema.json",
   "instrument": "WXT",
   "trigger_time": "2024-03-01T21:46:05.13Z",
+  "id": ["01708973486"],
   "ra": 120,
   "dec": 40,
   "ra_dec_error": 0.02,

--- a/gcn/notices/einstein_probe/wxt/alert.schema.json
+++ b/gcn/notices/einstein_probe/wxt/alert.schema.json
@@ -6,6 +6,7 @@
   "type": "object",
   "allOf": [
     { "$ref": "../../core/DateTime.schema.json" },
+    { "$ref": "../../core/Event.schema.json" },
     { "$ref": "../../core/Localization.schema.json" },
     { "$ref": "../../core/Reporter.schema.json" },
     { "$ref": "../../core/Statistics.schema.json" },


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
As discussed in previous PR #155 and #159 ,
> It is necessary to include a property such as the event name or trigger ID as a unique ID, which should be the same across both Notices and Circulars.

we prefer to use trigger id as the unique identifier. This PR add `id` property to EP Notice schema and example file.