### PR TITLE
Not required comment: Pointing.Schema.Json

### DIFF
--- a/gcn/notices/core/Pointing.schema.json
+++ b/gcn/notices/core/Pointing.schema.json
@@ -3,7 +3,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Instrument Pointing",
   "description": "Instrument pointing and rotational rates.",
-  "$comment": "Providers should $ref this schema directly but Attitudes.schema.json instead.",
   "type": "object",
   "properties": {
     "ra_pointing": {


### PR DESCRIPTION
Outdated comment exists, https://github.com/nasa-gcn/gcn-schema/issues/177. 
It directs to Attibutes.Schema.Json, which doesn't even exist.
