### PR TITLE
Add a unique ID to each coincident neutrino location shared.

### DIFF
--- a/gcn/notices/icecube/lvk_nu_track_search.example.json
+++ b/gcn/notices/icecube/lvk_nu_track_search.example.json
@@ -21,6 +21,7 @@
         "containment_probability": 0.9,
         "systematic_included": false
       },
+      "id": ["138590_39138551"],
       "event_pval_generic": 0.0191,
       "event_pval_bayesian": null
     },
@@ -33,6 +34,7 @@
         "containment_probability": 0.9,
         "systematic_included": false
       },
+      "id": ["138590_39164579"],
       "event_pval_generic": 0.0928,
       "event_pval_bayesian": 0.0656
     }

--- a/gcn/notices/icecube/lvk_nu_track_search.schema.json
+++ b/gcn/notices/icecube/lvk_nu_track_search.schema.json
@@ -65,7 +65,16 @@
     },
     "coincevent": {
       "type": "object",
-      "allOf": [{ "$ref": "../core/Localization.schema.json" }],
+      "allOf": [
+        {
+          "$ref": "../core/Localization.schema.json",
+          "description": "Per-event direction and uncertainty information"
+        },
+        {
+          "$ref": "../core/Event.schema.json",
+          "description": "Unique per-event identification information"
+        }
+      ],
       "properties": {
         "event_dt": {
           "description": "Time difference between LVK alert time and neutrino candidate [sec]",


### PR DESCRIPTION
# Description

Add unique identifier to each LVK coincident neutrino reported in IceCube LVK Alert Nu Track Search
notices.

# Related Issue(s)

Resolves #206




# Testing
Simple expansion of schema, with updated example. 
