### PR TITLE
make eventId not required

### DIFF
--- a/gcn/circulars.schema.json
+++ b/gcn/circulars.schema.json
@@ -36,7 +36,6 @@
     }
   },
   "required": [
-    "eventId",
     "submitter",
     "subject",
     "circularId",

--- a/gcn/circulars.schema.json
+++ b/gcn/circulars.schema.json
@@ -14,7 +14,12 @@
       "description": "Name, affiliation, and email address of the person who submitted the Circular, in the form `A. E. Einstein at IAS <albert.einstein@example.edu>`"
     },
     "submittedHow": {
-      "enum": ["web", "email", "email-legacy", "api"],
+      "enum": [
+        "web",
+        "email",
+        "email-legacy",
+        "api"
+      ],
       "description": "Specifies the method by which the user submitted the Circular"
     },
     "subject": {
@@ -26,10 +31,16 @@
       "description": "Circular ID assigned to the Circular in the GCN Circulars archive. This value is unique to each published Circular and increments by 1"
     },
     "format": {
-      "enum": ["text/plain", "text/markdown"],
+      "enum": [
+        "text/plain",
+        "text/markdown"
+      ],
       "description": "Format of the body text as a MIME type. See https://gcn.nasa.gov/docs/circulars/markdown for documentation on using Markdown in Circulars"
     },
-    "body": { "type": "string", "description": "Body text" },
+    "body": {
+      "type": "string",
+      "description": "Body text"
+    },
     "createdOn": {
       "type": "number",
       "description": "Date and time the Circular is accepted and published onto the GCN Circulars archive, formatted as a UNIX timestamp (milliseconds since the UNIX epoch)"

--- a/gcn/circulars.schema.json
+++ b/gcn/circulars.schema.json
@@ -14,12 +14,7 @@
       "description": "Name, affiliation, and email address of the person who submitted the Circular, in the form `A. E. Einstein at IAS <albert.einstein@example.edu>`"
     },
     "submittedHow": {
-      "enum": [
-        "web",
-        "email",
-        "email-legacy",
-        "api"
-      ],
+      "enum": ["web", "email", "email-legacy", "api"],
       "description": "Specifies the method by which the user submitted the Circular"
     },
     "subject": {
@@ -31,10 +26,7 @@
       "description": "Circular ID assigned to the Circular in the GCN Circulars archive. This value is unique to each published Circular and increments by 1"
     },
     "format": {
-      "enum": [
-        "text/plain",
-        "text/markdown"
-      ],
+      "enum": ["text/plain", "text/markdown"],
       "description": "Format of the body text as a MIME type. See https://gcn.nasa.gov/docs/circulars/markdown for documentation on using Markdown in Circulars"
     },
     "body": {
@@ -46,11 +38,5 @@
       "description": "Date and time the Circular is accepted and published onto the GCN Circulars archive, formatted as a UNIX timestamp (milliseconds since the UNIX epoch)"
     }
   },
-  "required": [
-    "submitter",
-    "subject",
-    "circularId",
-    "body",
-    "createdOn"
-  ]
+  "required": ["submitter", "subject", "circularId", "body", "createdOn"]
 }


### PR DESCRIPTION
# Description
Some circulars will not have an eventId so it is not a required field.

# Related Issue(s)
Resolves #209 

# Testing

