### PR TITLE
Remove spectrum enum

### DIFF
--- a/gcn/notices/core/Reporter.schema.json
+++ b/gcn/notices/core/Reporter.schema.json
@@ -21,12 +21,6 @@
       "enum": ["EM", "GW", "Neutrino"],
       "description": "Messenger of report; EM, GW or Neutrino"
     },
-    "spectrum": {
-      "enum": ["energy", "wavelength", "frequency"],
-      "description": "high-energy or optical or radio observations, if not parsed, then default band is energy",
-      "type": "string",
-      "default": "energy"
-    },
     "units": {
       "enum": ["keV", "nm", "Hz"],
       "description": "Units of band range, if not parsed, then default energy is keV",


### PR DESCRIPTION
The physical type (energy, wavelength, frequency) is implicit in the units.