### PR TITLE
Update units name

### DIFF
--- a/gcn/notices/chime/frb.detection.example.json
+++ b/gcn/notices/chime/frb.detection.example.json
@@ -16,7 +16,7 @@
   "importance": 0.9871308604784662,
   "sampling_time": 0.983,
   "spectral_band": [400, 800],
-  "units": "MHz",
+  "spectral_band_units": "MHz",
   "npol": 2,
   "tsys": 50,
   "description": "This alert was generated automatically by the CHIME/FRB Real-time Search Pipeline."

--- a/gcn/notices/chime/frb.subsequent.example.json
+++ b/gcn/notices/chime/frb.subsequent.example.json
@@ -18,7 +18,7 @@
   "association_probability": 0.932,
   "sampling_time": 0.983,
   "spectral_band": [400, 800],
-  "units": "MHz",
+  "spectral_band_units": "MHz",
   "npol": 2,
   "tsys": 50,
   "description": "This alert was generated automatically by the CHIME/FRB Real-time Search Pipeline."


### PR DESCRIPTION
# Description
Recently we have revised the name of core schema property.

`units` to `spectral_band_units`

Resolves #305 