### PR TITLE
fix flux density unit bug

### DIFF
--- a/gcn/notices/core/Spectral.example.json
+++ b/gcn/notices/core/Spectral.example.json
@@ -16,7 +16,7 @@
   "flux_time_range": [0, 20],
   "flux_density": 9.5e-7,
   "flux_density_error": 1.1e-7,
-  "flux_density_unit": "erg/cm2/keV",
+  "flux_density_unit": "erg/cm2/s/keV",
   "flux_density_spectral_point": 100,
   "flux_density_spectral_point_unit": "keV",
   "flux_density_time_range": [0, 10],

--- a/gcn/notices/core/Spectral.schema.json
+++ b/gcn/notices/core/Spectral.schema.json
@@ -84,7 +84,7 @@
     },
     "flux_density_unit": {
       "type": "string",
-      "enum": ["erg/cm2/s/Hz", "erg/cm2/keV", "erg/cm2/s/nm"],
+      "enum": ["erg/cm2/s/Hz", "erg/cm2/s/keV", "erg/cm2/s/nm"],
       "default": "erg/cm2/s/keV",
       "description": "Unit of the flux density: frequency-based [erg/cm2/s/Hz], energy-based [erg/cm2/s/keV], or wavelength-based [erg/cm2/s/nm]. Default is [erg/cm2/s/keV]."
     },


### PR DESCRIPTION
# Description
Fix a bug in flux density unit enum in Spectral.schema.json.

No other schema is using this property. Nothing broke wrt existing mission schemas.